### PR TITLE
Create `classical` superclass

### DIFF
--- a/src/unitaria/nodes/classical/classical.py
+++ b/src/unitaria/nodes/classical/classical.py
@@ -1,0 +1,62 @@
+from abc import abstractmethod
+
+import numpy as np
+
+from ..node import Node
+from unitaria.subspace import Subspace
+
+
+class Classical(Node):
+    """
+    Abstract superclass for nodes performing classical computation.
+
+    :param input_bits:
+        The number of bits in the input of the computed function
+    :param output_bits:
+        The number of bits in the output of the computed function
+    """
+
+    input_bits: int
+    output_bits: int
+
+    def __init__(self, input_bits: int, output_bits):
+        super().__init__(2**input_bits, 2**output_bits)
+        if input_bits < 1 or output_bits < 1:
+            raise ValueError()
+        self.input_bits = input_bits
+        self.output_bits = output_bits
+
+    def _subspace_in(self) -> Subspace:
+        return Subspace(self.input_bits, max(0, self.output_bits - self.input_bits))
+
+    def _subspace_out(self) -> Subspace:
+        return Subspace(self.output_bits, max(0, self.input_bits - self.output_bits))
+
+    def _normalization(self) -> float:
+        return 1
+
+    @abstractmethod
+    def compute_classical(self, input: np.ndarray) -> np.ndarray:
+        raise NotImplementedError
+
+    @abstractmethod
+    def compute_reverse_classical(self, input: np.ndarray) -> np.ndarray:
+        raise NotImplementedError
+
+    def compute(self, input: np.ndarray) -> np.ndarray:
+        outer_shape = list(input.shape[:-1])
+        output = np.zeros(outer_shape + [2**self.output_bits], dtype=np.complex128)
+        output = output.reshape([-1, 2**self.output_bits])
+        input = input.reshape([-1, 2**self.input_bits])
+        indices = np.arange(2**self.input_bits, dtype=np.int32)
+        output[:, self.compute_classical(indices)] = input[:, indices]
+        return output.reshape(outer_shape + [2**self.output_bits])
+
+    def compute_adjoint(self, input: np.ndarray) -> np.ndarray:
+        outer_shape = list(input.shape[:-1])
+        output = np.zeros(outer_shape + [2**self.input_bits], dtype=np.complex128)
+        output = output.reshape([-1, 2**self.input_bits])
+        input = input.reshape([-1, 2**self.output_bits])
+        indices = np.arange(2**self.output_bits, dtype=np.int32)
+        output[:, self.compute_reverse_classical(indices)] = input[:, indices]
+        return output.reshape(outer_shape + [2**self.input_bits])

--- a/src/unitaria/nodes/classical/constant_integer_addition.py
+++ b/src/unitaria/nodes/classical/constant_integer_addition.py
@@ -1,12 +1,13 @@
 import numpy as np
 
 from ..node import Node
+from .classical import Classical
 from unitaria.subspace import Subspace
 from unitaria.circuit import Circuit
 from unitaria.circuits.arithmetic import const_addition_circuit
 
 
-class ConstantIntegerAddition(Node):
+class ConstantIntegerAddition(Classical):
     """
     Node implementing the (wrapping) addition of a constant to an integer.
 
@@ -20,9 +21,7 @@ class ConstantIntegerAddition(Node):
     constant: int
 
     def __init__(self, bits: int, constant: int):
-        super().__init__(2**bits, 2**bits)
-        if bits < 1:
-            raise ValueError()
+        super().__init__(bits, bits)
         self.bits = bits
         self.constant = constant
 
@@ -38,14 +37,11 @@ class ConstantIntegerAddition(Node):
     def _subspace_out(self) -> Subspace:
         return Subspace(self.bits, 2)
 
-    def _normalization(self) -> float:
-        return 1
+    def compute_classical(self, input: np.ndarray) -> np.ndarray:
+        return (input + self.constant) % 2**self.bits
 
-    def compute(self, input: np.ndarray) -> np.ndarray:
-        return np.roll(input, self.constant, axis=-1)
-
-    def compute_adjoint(self, input: np.ndarray) -> np.ndarray:
-        return np.roll(input, -self.constant, axis=-1)
+    def compute_reverse_classical(self, input: np.ndarray) -> np.ndarray:
+        return (input - self.constant) % 2**self.bits
 
     def _circuit(self) -> Circuit:
         circuit = const_addition_circuit(range(self.bits), self.constant, [self.bits, self.bits + 1])

--- a/src/unitaria/nodes/classical/increment.py
+++ b/src/unitaria/nodes/classical/increment.py
@@ -2,12 +2,13 @@ import numpy as np
 import tequila as tq
 
 from ..node import Node
+from .classical import Classical
 from unitaria.subspace import Subspace
 from unitaria.circuit import Circuit
 from unitaria.circuits.arithmetic import increment_circuit_single_ancilla
 
 
-class Increment(Node):
+class Increment(Classical):
     """
     Node implementing the (wrapping) increment of an integer.
 
@@ -18,9 +19,7 @@ class Increment(Node):
     bits: int
 
     def __init__(self, bits: int):
-        super().__init__(2**bits, 2**bits)
-        if bits < 1:
-            raise ValueError()
+        super().__init__(bits, bits)
         self.bits = bits
 
     def children(self) -> list[Node]:
@@ -41,14 +40,11 @@ class Increment(Node):
         else:
             return Subspace(self.bits, 1)
 
-    def _normalization(self) -> float:
-        return 1
+    def compute_classical(self, input: np.ndarray) -> np.ndarray:
+        return (input + 1) % 2**self.bits
 
-    def compute(self, input: np.ndarray) -> np.ndarray:
-        return np.roll(input, 1, axis=-1)
-
-    def compute_adjoint(self, input: np.ndarray) -> np.ndarray:
-        return np.roll(input, -1, axis=-1)
+    def compute_reverse_classical(self, input: np.ndarray) -> np.ndarray:
+        return (input - 1) % 2**self.bits
 
     def _circuit(self) -> Circuit:
         if self.bits <= 3:

--- a/src/unitaria/nodes/classical/integer_addition.py
+++ b/src/unitaria/nodes/classical/integer_addition.py
@@ -1,12 +1,12 @@
 import numpy as np
 
 from ..node import Node
-from unitaria.subspace import Subspace
+from .classical import Classical
 from unitaria.circuit import Circuit
 from unitaria.circuits.arithmetic import addition_circuit
 
 
-class IntegerAddition(Node):
+class IntegerAddition(Classical):
     """
     Node implementing the (wrapping) addition of two integers.
 
@@ -22,7 +22,7 @@ class IntegerAddition(Node):
     target_bits: int
 
     def __init__(self, source_bits: int, target_bits: int):
-        super().__init__(2 ** (source_bits + target_bits), 2 ** (source_bits + target_bits))
+        super().__init__(source_bits + target_bits, source_bits + target_bits)
         # TODO: Restriction is because the ancilla free construction needs two source bits.
         #  I know how to fix this but haven't implemented it yet.
         if source_bits < 2 or target_bits < source_bits:
@@ -36,34 +36,17 @@ class IntegerAddition(Node):
     def parameters(self) -> dict:
         return {"source_bits": self.source_bits, "target_bits": self.target_bits}
 
-    def _subspace_in(self) -> Subspace:
-        return Subspace(self.source_bits + self.target_bits)
+    def compute_classical(self, input: np.ndarray) -> np.ndarray:
+        input1 = input % 2**self.source_bits
+        input2 = input // 2**self.source_bits
+        input2 = (input2 + input1) % 2**self.target_bits
+        return input1 + input2 * 2**self.source_bits
 
-    def _subspace_out(self) -> Subspace:
-        return Subspace(self.source_bits + self.target_bits)
-
-    def _normalization(self) -> float:
-        return 1
-
-    def compute(self, input: np.ndarray) -> np.ndarray:
-        old_shape = input.shape
-        N = 2**self.source_bits
-        M = 2**self.target_bits
-        input = input.reshape((-1, M, N))
-        result = np.zeros_like(input)
-        for val in range(N):
-            result[:, :, val] += np.roll(input[:, :, val], val, axis=-1)
-        return result.reshape(old_shape)
-
-    def compute_adjoint(self, input: np.ndarray) -> np.ndarray:
-        old_shape = input.shape
-        N = 2**self.source_bits
-        M = 2**self.target_bits
-        input = input.reshape((-1, M, N))
-        result = np.zeros_like(input)
-        for val in range(N):
-            result[:, :, val] += np.roll(input[:, :, val], -val, axis=-1)
-        return result.reshape(old_shape)
+    def compute_reverse_classical(self, input: np.ndarray) -> np.ndarray:
+        input1 = input % 2**self.source_bits
+        input2 = input // 2**self.source_bits
+        input2 = (input2 - input1) % 2**self.target_bits
+        return input1 + input2 * 2**self.source_bits
 
     def _circuit(self) -> Circuit:
         source = range(self.source_bits)


### PR DESCRIPTION
Fixes #46. This is a common superclass for nodes that perform some classical computation, i.e. integer arithmetics. It requires the subclasses to implement `compute_classical` and `compute_reverse_classical`. It then provides default implementations of `compute`, `compute_adjoint`, `_normalization`, and `_subspace_{in|out}`.

For now the default implementations of the subspaces are often overwritten, but this should change once we implement ancillas.

Open questions:

* How can we improve the interface in case nodes have more than one input (see `IntegerAddition`)?
* How can we improve the interplay with `ProxyNode` (e.g. right now `ConstantIntegerMultiplication` is not subclass of `Classical`)?