### PR TITLE
Faster classical nodes

### DIFF
--- a/src/unitaria/nodes/classical/constant_integer_addition.py
+++ b/src/unitaria/nodes/classical/constant_integer_addition.py
@@ -45,6 +45,12 @@ class ConstantIntegerAddition(Classical):
     def compute_reverse_classical(self, input: np.ndarray) -> np.ndarray:
         return (input - self.constant) % 2**self.bits
 
+    def compute(self, input: np.ndarray) -> np.ndarray:
+        return np.roll(input, self.constant, axis=-1)
+
+    def compute_adjoint(self, input: np.ndarray) -> np.ndarray:
+        return np.roll(input, -self.constant, axis=-1)
+
     def _circuit(
         self, target: Sequence[int], clean_ancillae: Sequence[int], borrowed_ancillae: Sequence[int]
     ) -> Circuit:

--- a/src/unitaria/nodes/classical/increment.py
+++ b/src/unitaria/nodes/classical/increment.py
@@ -42,6 +42,12 @@ class Increment(Classical):
     def compute_reverse_classical(self, input: np.ndarray) -> np.ndarray:
         return (input - 1) % 2**self.bits
 
+    def compute(self, input: np.ndarray) -> np.ndarray:
+        return np.roll(input, 1, axis=-1)
+
+    def compute_adjoint(self, input: np.ndarray) -> np.ndarray:
+        return np.roll(input, -1, axis=-1)
+
     def _circuit(
         self, target: Sequence[int], clean_ancillae: Sequence[int], borrowed_ancillae: Sequence[int]
     ) -> Circuit:

--- a/src/unitaria/nodes/classical/integer_addition.py
+++ b/src/unitaria/nodes/classical/integer_addition.py
@@ -50,6 +50,24 @@ class IntegerAddition(Classical):
         input2 = (input2 - input1) % 2**self.target_bits
         return input1 + input2 * 2**self.source_bits
 
+    def compute(self, input: np.ndarray) -> np.ndarray:
+        old_shape = input.shape
+        N = 2**self.source_bits
+        M = 2**self.target_bits
+        input = input.reshape((-1, M, N))
+        shift = (np.arange(M)[:, None] - np.arange(N)) % M
+        result = input[:, shift, np.arange(N)]
+        return result.reshape(old_shape)
+
+    def compute_adjoint(self, input: np.ndarray) -> np.ndarray:
+        old_shape = input.shape
+        N = 2**self.source_bits
+        M = 2**self.target_bits
+        input = input.reshape((-1, M, N))
+        shift = (np.arange(M)[:, None] + np.arange(N)) % M
+        result = input[:, shift, np.arange(N)]
+        return result.reshape(old_shape)
+
     def _circuit(
         self, target: Sequence[int], clean_ancillae: Sequence[int], borrowed_ancillae: Sequence[int]
     ) -> Circuit:


### PR DESCRIPTION
Adds direct implementations for `compute` and `compute_adjoint` in classical nodes, instead of using the generic implementation which first maps all indices.

Closes https://github.com/tequilahub/unitaria/issues/59.