### PR TITLE
Fix doctests and run in CI

### DIFF
--- a/.github/workflows/ci_pytest.yml
+++ b/.github/workflows/ci_pytest.yml
@@ -24,6 +24,4 @@ jobs:
       - name: Install dependencies
         run: uv sync --dev
       - name: Run tests
-        run: uv run pytest tests
-      - name: Run doctest
-        run: uv run pytest --doctest-glob="README.md" README.md
+        run: uv run pytest

--- a/.github/workflows/ci_pytest.yml
+++ b/.github/workflows/ci_pytest.yml
@@ -17,11 +17,13 @@ jobs:
         with:
           python-version: "3.12"
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
         with:
-          version: "0.10.9"
+          version: "0.11.3"
           enable-cache: true
       - name: Install dependencies
         run: uv sync --dev
       - name: Run tests
         run: uv run pytest tests
+      - name: Run doctest
+        run: uv run pytest --doctest-glob="README.md" README.md

--- a/.github/workflows/ci_ruff.yml
+++ b/.github/workflows/ci_ruff.yml
@@ -14,6 +14,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: astral-sh/ruff-action@v3
         with:
-          version: "0.15.5"
+          version: "0.15.9"
       - run: "ruff format --check --diff"
       - run: "ruff check"

--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ quantum computers. It allows constructing quantum algorithms using a simple,
 `numpy`-like syntax.
 
 ```python
->>> from unitaria.nodes import ConstantVector, Identity
+>>> import unitaria as ut
 >>> import numpy as np
->>> result = Identity(1) @ ConstantVector(np.array([3, 4]))
->>> result.draw()
+>>> result = ut.Identity(bits=1) @ ut.ConstantVector(np.array([3, 4]))
+>>> print(result.draw())
 Mul
 ├── ConstantVector{'vec': array([3, 4])}
 └── Identity{'subspace': Subspace(1)}
@@ -19,11 +19,15 @@ Mul
 array([3., 4.])
 >>> result.normalization
 np.float64(5.0)
->>> result.circuit
-Circuit(tq_circuit=circuit: 
-Ry(target=(0,), parameter=1.8545904360032246)
+>>> result.circuit()
+Circuit(_tq_circuit=circuit: 
 GlobalPhase(target=(), control=(), parameter=0.0)
+Ry(target=(0,), parameter=1.8545904360032246)
+Rx(target=(0,), parameter=0.0)
+Rx(target=(0,), parameter=-0.0)
+Rx(target=(0,), parameter=0.0)
 )
+
 ```
 
 [**Documentation**](https://tequilahub.github.io/unitaria/index.html)

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ np.float64(5.0)
 >>> result.circuit()
 Circuit(_tq_circuit=circuit: 
 GlobalPhase(target=(), control=(), parameter=0.0)
-Ry(target=(0,), parameter=1.8545904360032246)
+Ry(target=(0,), parameter=1.854590436003224)
 Rx(target=(0,), parameter=0.0)
 Rx(target=(0,), parameter=-0.0)
 Rx(target=(0,), parameter=0.0)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,8 +56,11 @@ Documentation = "https://tequilahub.github.io/unitaria/index.html"
 [tool.pytest.ini_options]
 addopts = [
   "--import-mode=importlib",
+  "--doctest-modules",
+  "--doctest-glob=README.md",
 ]
 pythonpath = ["src"]
+doctest_optionflags = ["NUMBER"]
 
 [tool.ruff]
 line-length = 120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ addopts = [
   "--import-mode=importlib",
   "--doctest-modules",
   "--doctest-glob=README.md",
+  "--doctest-glob=*.rst",
 ]
 pythonpath = ["src"]
 doctest_optionflags = ["NUMBER"]


### PR DESCRIPTION
Closes https://github.com/tequilahub/unitaria/issues/77 and adds a test to CI to make sure we notice the next time this breaks.

Also builds on https://github.com/tequilahub/unitaria/pull/83 and uses the new import style, so needs to be merged after that.

Also updated ruff and uv versions in CI.