### PR TITLE
Remove inherited methods from nodes in docs

### DIFF
--- a/docs/_templates/autosummary/class.rst
+++ b/docs/_templates/autosummary/class.rst
@@ -2,7 +2,7 @@
 
 .. currentmodule:: {{ module }}
 
-{% if name == "Node" %}
+{% if name in ["Node", "ProxyNode", "MultilinearNode"] %}
 .. autoclass:: {{ objname }}
    :show-inheritance:
    :members:
@@ -11,6 +11,9 @@
    :undoc-members:
    :private-members:
    :member-order: groupwise
+{% elif "_subspace_in" in members %}
+.. autoclass:: {{ objname }}
+   :show-inheritance:
 {% else %}
 .. autoclass:: {{ objname }}
    :show-inheritance:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -39,6 +39,7 @@ napoleon_use_ivar = True
 templates_path = ["_templates"]
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 autosummary_ignore_module_all = False
+autosummary_generate = True
 default_role = "py:obj"
 
 intersphinx_mapping = {

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,7 +10,7 @@ The basic object of this library is a `~unitaria.Node`, which may refer to a
 matrix or a vector.
 
 >>> import unitaria as ut
->>> ut.Identity(1)
+>>> ut.Identity(bits=1)
 Identity('subspace': Subspace(1))
 >>> import numpy as np
 >>> ut.ConstantVector(np.array([1, 2]))
@@ -22,7 +22,7 @@ more complex expressions, stored as a computational graph.
 
 >>> import unitaria as ut
 >>> import numpy as np
->>> print(ut.Identity(1) @ ut.ConstantVector(np.array([1, 2])))
+>>> print(ut.Identity(bits=1) @ ut.ConstantVector(np.array([1, 2])))
 Mul
 ├── ConstantVector{'vec': array([1, 2])}
 └── Identity{'subspace': Subspace(1)}
@@ -34,7 +34,7 @@ performs, available through the methods `~unitaria.Node.compute` and
 
 >>> import unitaria as ut
 >>> import numpy as np
->>> (ut.Identity(1) @ ut.ConstantVector(np.array([1, 2]))).toarray().real
+>>> (ut.Identity(bits=1) @ ut.ConstantVector(np.array([1, 2]))).toarray().real
 array([1., 2.])
 
 On the other hand, each node can give you a quantum circuit, a normalization
@@ -43,9 +43,9 @@ encoding of the vector. The convenience method `~unitaria.Node.simulate`
 combines this data, which should produce the same result as
 `~unitaria.Node.toarray`.
 
->>> unitaria as ut
+>>> import unitaria as ut
 >>> import numpy as np
->>> (ut.Identity(1) @ ut.ConstantVector(np.array([1, 2]))).simulate().real
+>>> (ut.Identity(bits=1) @ ut.ConstantVector(np.array([1, 2]))).simulate().real
 array([1., 2.])
 
 It can be checked wether the results of `~unitaria.Node.toarray` and

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,4 +1,4 @@
-API Reference
+Documentation
 =============
 
 `unitaria` is a library for working with so called "block encodings" of matrices
@@ -57,16 +57,22 @@ Custom nodes
 ------------
 
 Most basic operations are implemented already in this library. See `~unitaria.Node` for
-implementing custom nodes directly, or `~unitaria_node.ProxyNode` for implementing custom nodes
+implementing custom nodes directly, or `~unitaria.ProxyNode` for implementing custom nodes
 by decomposing them into other operations.
 
-.. rubric:: Modules
+.. only:: comment
 
-.. autosummary::
-   :toctree: generated
-   :recursive:
+   .. autosummary::
+      :toctree: generated
+      :recursive:
 
-   unitaria
+      unitaria
+
+
+API documentation
+-----------------
+
+See the documentation of the top-level module :doc:`generated/unitaria`.
 
 .. toctree::
    :hidden:

--- a/src/unitaria/__init__.py
+++ b/src/unitaria/__init__.py
@@ -4,9 +4,12 @@ from unitaria.subspace import Subspace, ControlledSubspace, ID, ZeroQubit
 from unitaria.circuit import Circuit
 from unitaria.verifier import verify
 
+# Documentation is generated differently for these classes, see
+# docs/_templates/autosummary/class.rst
 from unitaria.nodes.node import Node
 from unitaria.nodes.proxy_node import ProxyNode
 from unitaria.nodes.multilinear_node import MultilinearNode
+
 from unitaria.nodes.abstract_node import AbstractNode
 from unitaria.nodes.block_encoding import BlockEncoding
 

--- a/src/unitaria/nodes/basic/tensor.py
+++ b/src/unitaria/nodes/basic/tensor.py
@@ -16,7 +16,7 @@ class Tensor(Node):
 
     >>> import unitaria as ut
     >>> import numpy as np
-    >>> ut.Tensor(ut.Increment(1), ut.Identity(1)).toarray().real
+    >>> ut.Tensor(ut.Increment(bits=1), ut.Identity(bits=1)).toarray().real
     array([[0., 1., 0., 0.],
            [1., 0., 0., 0.],
            [0., 0., 0., 1.],
@@ -27,7 +27,7 @@ class Tensor(Node):
 
     >>> import unitaria as ut
     >>> import numpy as np
-    >>> (ut.Increment(1) & ut.Identity(1)).toarray().real
+    >>> (ut.Increment(bits=1) & ut.Identity(bits=1)).toarray().real
     array([[0., 1., 0., 0.],
            [1., 0., 0., 0.],
            [0., 0., 0., 1.],

--- a/src/unitaria/nodes/classical/classical.py
+++ b/src/unitaria/nodes/classical/classical.py
@@ -3,7 +3,7 @@ from typing import Sequence
 
 import numpy as np
 
-from ..node import Node
+from unitaria.nodes.node import Node
 from unitaria.subspace import Subspace
 
 

--- a/src/unitaria/nodes/classical/constant_integer_addition.py
+++ b/src/unitaria/nodes/classical/constant_integer_addition.py
@@ -2,8 +2,8 @@ from typing import Sequence
 
 import numpy as np
 
-from ..node import Node
-from .classical import Classical
+from unitaria.nodes.node import Node
+from unitaria.nodes.classical.classical import Classical
 from unitaria.subspace import Subspace
 from unitaria.circuit import Circuit
 from unitaria.circuits.arithmetic import const_addition_circuit

--- a/src/unitaria/nodes/classical/constant_integer_multiplication.py
+++ b/src/unitaria/nodes/classical/constant_integer_multiplication.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from ..node import Node
+from unitaria.nodes.node import Node
 from unitaria.subspace import Subspace
 
 from unitaria.nodes.classical.constant_integer_addition import ConstantIntegerAddition

--- a/src/unitaria/nodes/classical/increment.py
+++ b/src/unitaria/nodes/classical/increment.py
@@ -3,8 +3,8 @@ from typing import Sequence
 import numpy as np
 import tequila as tq
 
-from ..node import Node
-from .classical import Classical
+from unitaria.nodes.node import Node
+from unitaria.nodes.classical.classical import Classical
 from unitaria.subspace import Subspace
 from unitaria.circuit import Circuit
 from unitaria.circuits.arithmetic import increment_circuit_single_ancilla

--- a/src/unitaria/nodes/classical/integer_addition.py
+++ b/src/unitaria/nodes/classical/integer_addition.py
@@ -2,8 +2,8 @@ from typing import Sequence
 
 import numpy as np
 
-from ..node import Node
-from .classical import Classical
+from unitaria.nodes.node import Node
+from unitaria.nodes.classical.classical import Classical
 from unitaria.circuit import Circuit
 from unitaria.circuits.arithmetic import addition_circuit
 

--- a/src/unitaria/nodes/fourier_transform.py
+++ b/src/unitaria/nodes/fourier_transform.py
@@ -2,7 +2,9 @@ from typing import Sequence
 
 import numpy as np
 
-from unitaria import Node, Subspace, Circuit
+from unitaria.nodes.node import Node
+from unitaria.subspace import Subspace
+from unitaria.circuit import Circuit
 from unitaria.circuits.qft import qft_circuit
 
 

--- a/src/unitaria/nodes/inversion/pseudoinverse.py
+++ b/src/unitaria/nodes/inversion/pseudoinverse.py
@@ -11,7 +11,7 @@ class Pseudoinverse(ProxyNode):
     """
     This node implements the Moore-Penrose pseudoinverse of ``A`` with the
     given tolerance, if `condition` is the ratio between ``A.normalization`` and
-    ``A``s smallest singular value.
+    ``A`` s smallest singular value.
 
     Implements Theorem 41 from https://arxiv.org/abs/1806.01838
 

--- a/src/unitaria/nodes/node.py
+++ b/src/unitaria/nodes/node.py
@@ -267,7 +267,7 @@ class Node(ABC):
     def clean_ancilla_count(self) -> int:
         """
         Returns the number of borrowed ancillae used by the circuit of this node,
-        i.e. qubits that must be in state |0> at the beginning of the circuit and
+        i.e. qubits that must be in state ``|0>`` at the beginning of the circuit and
         will be returned to this state by the end of the circuit.
         """
         raise NotImplementedError

--- a/src/unitaria/subspace.py
+++ b/src/unitaria/subspace.py
@@ -414,8 +414,8 @@ class ControlledSubspace(Register):
         Specifically, if `case_one` and `case_zero` agree in a number of lowest
         qubits, this common part can be factored out. E.g.
 
-            >>> from unitaria.subspace import Subspace, ControlledSubspace
-            >>> ControlledSubspace(Subspace(2), Subspace(1, 1)).simplify()
+            >>> import unitaria as ut
+            >>> ut.ControlledSubspace(ut.Subspace(bits=2), ut.Subspace(bits=1, zero_qubits=1)).simplify()
             [ID, ControlledSubspace(case_zero=Subspace(1), case_one=Subspace(0, zero_qubits=1))]
         """
         min_len = min(len(self.case_zero.registers), len(self.case_one.registers))


### PR DESCRIPTION
The methods of `Node` add a lot of noise to the documentation of nodes. This PR removes all methods from most nodes, so that only the constructor can be seen. I think this helps.