### PR TITLE
String constructor for Subspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ quantum computers. It allows constructing quantum algorithms using a simple,
 ```python
 >>> import unitaria as ut
 >>> import numpy as np
->>> result = ut.Identity(bits=1) @ ut.ConstantVector(np.array([3, 4]))
+>>> result = ut.Identity(ut.Subspace.from_dim(2)) @ ut.ConstantVector(np.array([3, 4]))
 >>> print(result.draw())
 Mul
 ├── ConstantVector{'vec': array([3, 4])}
-└── Identity{'subspace': Subspace(1)}
+└── Identity{'subspace': Subspace("#")}
 >>> result.toarray().real
 array([3., 4.])
 >>> result.normalization

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,8 +10,8 @@ The basic object of this library is a `~unitaria.Node`, which may refer to a
 matrix or a vector.
 
 >>> import unitaria as ut
->>> ut.Identity(bits=1)
-Identity('subspace': Subspace(1))
+>>> ut.Identity(dim=2)
+Identity('subspace': Subspace("#"))
 >>> import numpy as np
 >>> ut.ConstantVector(np.array([1, 2]))
 ConstantVector('vec': array([1, 2]))
@@ -22,10 +22,10 @@ more complex expressions, stored as a computational graph.
 
 >>> import unitaria as ut
 >>> import numpy as np
->>> print(ut.Identity(bits=1) @ ut.ConstantVector(np.array([1, 2])))
+>>> print(ut.Identity(dim=2) @ ut.ConstantVector(np.array([1, 2])))
 Mul
 ├── ConstantVector{'vec': array([1, 2])}
-└── Identity{'subspace': Subspace(1)}
+└── Identity{'subspace': Subspace("#")}
 
 There are now two ways in which you can obtain the encoded vector of the above
 example. Each node contains a classical implementation of the operation it
@@ -34,7 +34,7 @@ performs, available through the methods `~unitaria.Node.compute` and
 
 >>> import unitaria as ut
 >>> import numpy as np
->>> (ut.Identity(bits=1) @ ut.ConstantVector(np.array([1, 2]))).toarray().real
+>>> (ut.Identity(dim=2) @ ut.ConstantVector(np.array([1, 2]))).toarray().real
 array([1., 2.])
 
 On the other hand, each node can give you a quantum circuit, a normalization
@@ -45,7 +45,7 @@ combines this data, which should produce the same result as
 
 >>> import unitaria as ut
 >>> import numpy as np
->>> (ut.Identity(bits=1) @ ut.ConstantVector(np.array([1, 2]))).simulate().real
+>>> (ut.Identity(dim=2) @ ut.ConstantVector(np.array([1, 2]))).simulate().real
 array([1., 2.])
 
 It can be checked wether the results of `~unitaria.Node.toarray` and

--- a/src/unitaria/__init__.py
+++ b/src/unitaria/__init__.py
@@ -1,6 +1,6 @@
 import unitaria.util as util
 
-from unitaria.subspace import Subspace, ControlledSubspace, ID, ZeroQubit
+from unitaria.subspace import Subspace, SubspaceFactor, ControlledSubspace, ZeroQubitSubspace, FullQubitSubspace
 from unitaria.circuit import Circuit
 from unitaria.verifier import verify
 
@@ -76,8 +76,9 @@ __all__ = [
     "QSVTCoefficients",
     "Scale",
     "Tensor",
+    "SubspaceFactor",
     "ControlledSubspace",
-    "ID",
-    "ZeroQubit",
+    "ZeroQubitSubspace",
+    "FullQubitSubspace",
     "util",
 ]

--- a/src/unitaria/nodes/basic/add.py
+++ b/src/unitaria/nodes/basic/add.py
@@ -58,11 +58,11 @@ class Add(ProxyNode):
         sqrt_A = np.sqrt(np.abs(self.A.normalization))
         sqrt_B = np.sqrt(np.abs(self.B.normalization))
         rotation_in = Tensor(
-            Identity(subspace=diag.subspace_in.case_zero()),
+            Identity(diag.subspace_in.case_zero()),
             ConstantVector(np.array([sqrt_A, sqrt_B])),
         )
         rotation_out = Tensor(
-            Identity(subspace=diag.subspace_out.case_zero()),
+            Identity(diag.subspace_out.case_zero()),
             ConstantVector(np.array([self.A.normalization / sqrt_A, self.B.normalization / sqrt_B])),
         )
 

--- a/src/unitaria/nodes/basic/block_diagonal.py
+++ b/src/unitaria/nodes/basic/block_diagonal.py
@@ -6,7 +6,7 @@ from unitaria.nodes.basic.controlled import Controlled
 from unitaria.nodes.basic.modify_control import ModifyControl
 from unitaria.nodes.basic.unsafe_multiplication import UnsafeMul
 from unitaria.nodes.basic.projection import Projection
-from unitaria.subspace import Subspace, ControlledSubspace
+from unitaria.subspace import Subspace
 
 
 class BlockDiagonal(ProxyNode):
@@ -41,8 +41,8 @@ class BlockDiagonal(ProxyNode):
         subspace_in = _controlled_qubits(A_controlled.subspace_in, B_controlled.subspace_in)
         subspace_mid = _controlled_qubits(A_controlled.subspace_out, B_controlled.subspace_in)
         subspace_out = _controlled_qubits(A_controlled.subspace_out, B_controlled.subspace_out)
-        controlled_bits_A = A_controlled.subspace_in.total_qubits - A_controlled.subspace_in.trailing_zeros()
-        controlled_bits_B = B_controlled.subspace_in.total_qubits - B_controlled.subspace_in.trailing_zeros()
+        controlled_bits_A = A_controlled.subspace_in.total_qubits - A_controlled.subspace_in.initial_zeros()
+        controlled_bits_B = B_controlled.subspace_in.total_qubits - B_controlled.subspace_in.initial_zeros()
 
         A_controlled = ModifyControl(A_controlled, max(0, controlled_bits_B - controlled_bits_A), True)
         A_controlled = UnsafeMul(
@@ -85,13 +85,13 @@ class BlockDiagonal(ProxyNode):
 
 
 def _controlled_qubits(A_controlled: Subspace, B_controlled: Subspace) -> Subspace:
-    zeros = max(A_controlled.trailing_zeros(), B_controlled.trailing_zeros())
+    zeros = max(A_controlled.initial_zeros(), B_controlled.initial_zeros())
     A = A_controlled.case_one()
     B = B_controlled.case_one()
     controlled_qubits = max(A.total_qubits, B.total_qubits)
-    case_zero = Subspace(A.tensor_factors, zero_qubits=max(0, controlled_qubits - A.total_qubits))
-    case_one = Subspace(B.tensor_factors, zero_qubits=max(0, controlled_qubits - B.total_qubits))
-    return Subspace([ControlledSubspace(case_zero, case_one)], zero_qubits=zeros)
+    case_zero = Subspace("0" * max(0, controlled_qubits - A.total_qubits)) & A
+    case_one = Subspace("0" * max(0, controlled_qubits - B.total_qubits)) & B
+    return Subspace("0" * zeros) & (case_zero | case_one)
 
 
 Node.__or__ = lambda A, B: BlockDiagonal(A, B)

--- a/src/unitaria/nodes/basic/block_horizontal.py
+++ b/src/unitaria/nodes/basic/block_horizontal.py
@@ -45,7 +45,7 @@ class BlockHorizontal(ProxyNode):
         diag = BlockDiagonal(A_permuted, B_permuted)
 
         rotation_out = Tensor(
-            Identity(subspace=diag.subspace_out.case_zero()),
+            Identity(diag.subspace_out.case_zero()),
             ConstantVector(np.array([self.A.normalization, self.B.normalization])),
         )
 

--- a/src/unitaria/nodes/basic/block_vertical.py
+++ b/src/unitaria/nodes/basic/block_vertical.py
@@ -45,7 +45,7 @@ class BlockVertical(ProxyNode):
         diag = BlockDiagonal(A_permuted, B_permuted)
 
         rotation_in = Tensor(
-            Identity(subspace=diag.subspace_out.case_zero()),
+            Identity(diag.subspace_out.case_zero()),
             ConstantVector(np.array([self.A.normalization, self.B.normalization])),
         )
 

--- a/src/unitaria/nodes/basic/compute_projection.py
+++ b/src/unitaria/nodes/basic/compute_projection.py
@@ -8,6 +8,8 @@ from unitaria.circuit import Circuit
 from unitaria.subspace import Subspace
 from unitaria.nodes.node import Node
 
+# TODO: Rename this file
+
 
 class SubspaceCircuit(Node):
     """
@@ -32,10 +34,10 @@ class SubspaceCircuit(Node):
         return []
 
     def _subspace_in(self) -> Subspace:
-        return Subspace(self.subspace.tensor_factors, zero_qubits=1)
+        return Subspace("0") & self.subspace
 
     def _subspace_out(self) -> Subspace:
-        return Subspace(self.subspace.tensor_factors, zero_qubits=1)
+        return Subspace("0") & self.subspace
 
     def _normalization(self) -> float:
         return 1

--- a/src/unitaria/nodes/basic/controlled.py
+++ b/src/unitaria/nodes/basic/controlled.py
@@ -17,11 +17,11 @@ class Controlled(Node):
 
     def _subspace_in(self) -> Subspace:
         subspace_in_A = self.A.subspace_in
-        return Subspace(bits=0, zero_qubits=subspace_in_A.total_qubits) | subspace_in_A
+        return Subspace("0" * subspace_in_A.total_qubits) | subspace_in_A
 
     def _subspace_out(self) -> Subspace:
         subspace_out_A = self.A.subspace_out
-        return Subspace(bits=0, zero_qubits=subspace_out_A.total_qubits) | subspace_out_A
+        return Subspace("0" * subspace_out_A.total_qubits) | subspace_out_A
 
     def _normalization(self) -> float:
         return self.A.normalization

--- a/src/unitaria/nodes/basic/identity.py
+++ b/src/unitaria/nodes/basic/identity.py
@@ -17,13 +17,7 @@ class Identity(Node):
 
     subspace: Subspace
 
-    def __init__(self, subspace: Subspace = None, *, bits: int = None):
-        if subspace is not None:
-            subspace = subspace
-        elif bits is not None:
-            subspace = Subspace(bits=bits)
-        else:
-            raise TypeError("Identity constructor requires subspace=... or bits=... as keyword arguments")
+    def __init__(self, subspace: Subspace = None):
         super().__init__(subspace.dimension, subspace.dimension)
         self.subspace = subspace
 

--- a/src/unitaria/nodes/basic/identity.py
+++ b/src/unitaria/nodes/basic/identity.py
@@ -11,15 +11,26 @@ class Identity(Node):
     """
     Node representing the identity matrix on a given vectorspace
 
+    Should specify exactly one of ``subspace`` or ``dim``
+
     :param subspace:
         The domain of the identity matrix
+    :param dim:
+        The dimension of the domain
     """
 
     subspace: Subspace
 
-    def __init__(self, subspace: Subspace = None):
-        super().__init__(subspace.dimension, subspace.dimension)
-        self.subspace = subspace
+    def __init__(self, subspace: Subspace | None = None, *, dim: int | None = None):
+        if dim is not None:
+            if subspace is not None:
+                raise ValueError("Either subspace or dim has to be specified")
+            self.subspace = Subspace.from_dim(dim)
+        else:
+            if subspace is None:
+                raise ValueError("Either subspace or dim has to be specified")
+            self.subspace = subspace
+        super().__init__(self.subspace.dimension, self.subspace.dimension)
 
     def children(self) -> list[Node]:
         return []

--- a/src/unitaria/nodes/basic/modify_control.py
+++ b/src/unitaria/nodes/basic/modify_control.py
@@ -3,7 +3,7 @@ from typing import Sequence
 import numpy as np
 import tequila as tq
 
-from unitaria.subspace import Subspace, ControlledSubspace
+from unitaria.subspace import Subspace
 from unitaria.nodes.node import Node
 from unitaria.circuit import Circuit
 
@@ -16,7 +16,7 @@ class ModifyControl(Node):
         swap_control_state: bool = False,
     ):
         self.A = A
-        expand_control = Subspace(bits=expand_control_bits)
+        expand_control = Subspace("#" * expand_control_bits)
         super().__init__(
             (A.dimension_in - 1) * expand_control.dimension + 1, (A.dimension_out - 1) * expand_control.dimension + 1
         )
@@ -34,33 +34,21 @@ class ModifyControl(Node):
 
     def _subspace_in(self) -> Subspace:
         subspace_one = self.A.subspace_in.case_one() & self.expand_control
-        subspace_zero = Subspace(bits=0, zero_qubits=subspace_one.total_qubits)
+        subspace_zero = Subspace("0" * subspace_one.total_qubits)
 
         if self.swap_control_state:
-            return Subspace(
-                [ControlledSubspace(subspace_one, subspace_zero)],
-                zero_qubits=self.A.subspace_in.trailing_zeros(),
-            )
+            return Subspace("0" * self.A.subspace_in.initial_zeros()) & (subspace_one | subspace_zero)
         else:
-            return Subspace(
-                [ControlledSubspace(subspace_zero, subspace_one)],
-                zero_qubits=self.A.subspace_in.trailing_zeros(),
-            )
+            return Subspace("0" * self.A.subspace_in.initial_zeros()) & (subspace_zero | subspace_one)
 
     def _subspace_out(self) -> Subspace:
         subspace_one = self.A.subspace_out.case_one() & self.expand_control
-        subspace_zero = Subspace(bits=0, zero_qubits=subspace_one.total_qubits)
+        subspace_zero = Subspace("0" * subspace_one.total_qubits)
 
         if self.swap_control_state:
-            return Subspace(
-                [ControlledSubspace(subspace_one, subspace_zero)],
-                zero_qubits=self.A.subspace_out.trailing_zeros(),
-            )
+            return Subspace("0" * self.A.subspace_out.initial_zeros()) & (subspace_one | subspace_zero)
         else:
-            return Subspace(
-                [ControlledSubspace(subspace_zero, subspace_one)],
-                zero_qubits=self.A.subspace_out.trailing_zeros(),
-            )
+            return Subspace("0" * self.A.subspace_out.initial_zeros()) & (subspace_zero | subspace_one)
 
     def _normalization(self) -> float:
         return self.A.normalization

--- a/src/unitaria/nodes/basic/mul.py
+++ b/src/unitaria/nodes/basic/mul.py
@@ -53,7 +53,7 @@ class Mul(ProxyNode):
         B_permuted = UnsafeMul(Adjoint(permute_B), self.B)
         projection_subspace = A_permuted.subspace_out
         projection_required = not self.skip_projection
-        if projection_subspace == Subspace(bits=projection_subspace.total_qubits):
+        if projection_subspace == Subspace("#" * projection_subspace.total_qubits):
             projection_required = False
         if self.A.is_guaranteed_unitary() or self.B.is_guaranteed_unitary():
             projection_required = False
@@ -62,8 +62,8 @@ class Mul(ProxyNode):
             # once match_nonzero is improved
             if A_permuted.subspace_out.total_qubits < B_permuted.subspace_in.total_qubits:
                 projection_subspace = B_permuted.subspace_in
-            A_permuted = Tensor(A_permuted, Identity(subspace=Subspace(bits=0, zero_qubits=1)))
-            B_permuted = Tensor(B_permuted, Identity(subspace=Subspace(bits=0, zero_qubits=1)))
+            A_permuted = Tensor(A_permuted, Identity(Subspace("0")))
+            B_permuted = Tensor(B_permuted, Identity(Subspace("0")))
             return UnsafeMul(UnsafeMul(A_permuted, SubspaceCircuit(projection_subspace)), B_permuted)
         else:
             return UnsafeMul(A_permuted, B_permuted)

--- a/src/unitaria/nodes/basic/tensor.py
+++ b/src/unitaria/nodes/basic/tensor.py
@@ -98,12 +98,12 @@ class Tensor(Node):
     def _subspace_in(self) -> Subspace:
         subspace_A = self.A.subspace_in
         subspace_B = self.B.subspace_in
-        return subspace_A & subspace_B
+        return subspace_B & subspace_A
 
     def _subspace_out(self) -> Subspace:
         subspace_A = self.A.subspace_out
         subspace_B = self.B.subspace_out
-        return subspace_A & subspace_B
+        return subspace_B & subspace_A
 
     def _normalization(self) -> float:
         return self.A.normalization * self.B.normalization

--- a/src/unitaria/nodes/basic/tensor.py
+++ b/src/unitaria/nodes/basic/tensor.py
@@ -16,7 +16,7 @@ class Tensor(Node):
 
     >>> import unitaria as ut
     >>> import numpy as np
-    >>> ut.Tensor(ut.Increment(bits=1), ut.Identity(bits=1)).toarray().real
+    >>> ut.Tensor(ut.Increment(bits=1), ut.Identity(dim=2)).toarray().real
     array([[0., 1., 0., 0.],
            [1., 0., 0., 0.],
            [0., 0., 0., 1.],
@@ -27,7 +27,7 @@ class Tensor(Node):
 
     >>> import unitaria as ut
     >>> import numpy as np
-    >>> (ut.Increment(bits=1) & ut.Identity(bits=1)).toarray().real
+    >>> (ut.Increment(bits=1) & ut.Identity(dim=2)).toarray().real
     array([[0., 1., 0., 0.],
            [1., 0., 0., 0.],
            [0., 0., 0., 1.],

--- a/src/unitaria/nodes/basic/unsafe_multiplication.py
+++ b/src/unitaria/nodes/basic/unsafe_multiplication.py
@@ -27,13 +27,12 @@ class UnsafeMul(Node):
     B: Node
 
     def __init__(self, A: Node, B: Node):
-        if not A.subspace_out.match_nonzero(B.subspace_in):
-            raise ValueError(f"Non matching qubit maps {A.subspace_out} and {B.subspace_in}")
-
-        super().__init__(A.dimension_in, B.dimension_out)
-
         self.A = A
         self.B = B
+        if not A.subspace_out.match_nonzero(B.subspace_in):
+            raise ValueError(f"Non matching qubit maps {repr(A.subspace_out)} and {repr(B.subspace_in)}")
+
+        super().__init__(A.dimension_in, B.dimension_out)
 
     def children(self) -> list[Node]:
         return [self.A, self.B]
@@ -58,17 +57,11 @@ class UnsafeMul(Node):
 
     def _subspace_in(self) -> Subspace:
         max_qubits = max(self.A.subspace_in.total_qubits, self.B.subspace_out.total_qubits)
-        return Subspace(
-            self.A.subspace_in.tensor_factors,
-            zero_qubits=max_qubits - self.A.subspace_in.total_qubits,
-        )
+        return Subspace("0" * (max_qubits - self.A.subspace_in.total_qubits)) & self.A.subspace_in
 
     def _subspace_out(self) -> Subspace:
         max_qubits = max(self.A.subspace_in.total_qubits, self.B.subspace_out.total_qubits)
-        return Subspace(
-            self.B.subspace_out.tensor_factors,
-            zero_qubits=max_qubits - self.B.subspace_out.total_qubits,
-        )
+        return Subspace("0" * (max_qubits - self.B.subspace_out.total_qubits)) & self.B.subspace_out
 
     def _normalization(self) -> float:
         return self.A.normalization * self.B.normalization

--- a/src/unitaria/nodes/classical/classical.py
+++ b/src/unitaria/nodes/classical/classical.py
@@ -30,10 +30,10 @@ class Classical(Node):
         super().__init__(2 ** sum(self.input_bits), 2 ** sum(self.output_bits))
 
     def _subspace_in(self) -> Subspace:
-        return Subspace(bits=sum(self.input_bits), zero_qubits=max(0, sum(self.output_bits) - sum(self.input_bits)))
+        return Subspace("0" * max(0, sum(self.output_bits) - sum(self.input_bits)) + "#" * sum(self.input_bits))
 
     def _subspace_out(self) -> Subspace:
-        return Subspace(bits=sum(self.output_bits), zero_qubits=max(0, sum(self.input_bits) - sum(self.output_bits)))
+        return Subspace("0" * max(0, sum(self.input_bits) - sum(self.output_bits)) + "#" * sum(self.output_bits))
 
     def _normalization(self) -> float:
         return 1

--- a/src/unitaria/nodes/classical/constant_integer_addition.py
+++ b/src/unitaria/nodes/classical/constant_integer_addition.py
@@ -34,10 +34,10 @@ class ConstantIntegerAddition(Classical):
         return {"bits": self.bits, "constant": self.constant}
 
     def _subspace_in(self) -> Subspace:
-        return Subspace(bits=self.bits)
+        return Subspace("#" * self.bits)
 
     def _subspace_out(self) -> Subspace:
-        return Subspace(bits=self.bits)
+        return Subspace("#" * self.bits)
 
     def is_guaranteed_unitary(self) -> bool:
         return True

--- a/src/unitaria/nodes/classical/constant_integer_multiplication.py
+++ b/src/unitaria/nodes/classical/constant_integer_multiplication.py
@@ -47,23 +47,23 @@ class ConstantIntegerMultiplication(ProxyNode):
     def definition(self) -> Node:
         if self.bits == 1:
             assert self.constant == 1
-            return Identity(subspace=Subspace(bits=1))
+            return Identity(Subspace("#"))
         result = None
         for i in reversed(range(self.bits - 1)):
             add_bits = self.bits - 1 - i
             c = (self.constant >> 1) & ((1 << add_bits) - 1)
             const_add = BlockDiagonal(
-                Identity(subspace=Subspace(bits=add_bits)),
+                Identity(Subspace("#" * add_bits)),
                 ConstantIntegerAddition(bits=add_bits, constant=c),
             )
-            permutation = PermuteFactors(Subspace(bits=add_bits + 1), [add_bits] + list(range(add_bits)))
+            permutation = PermuteFactors(Subspace("#" * (add_bits + 1)), [add_bits] + list(range(add_bits)))
             # TODO: The skip_projection can be removed onces this is done automatically
             const_add = Mul(
                 Adjoint(permutation),
                 Mul(const_add, permutation, skip_projection=True),
                 skip_projection=True,
             )
-            const_add = Identity(subspace=Subspace(bits=i)) & const_add
+            const_add = Identity(Subspace("#" * i)) & const_add
             if result is not None:
                 result = Mul(result, const_add, skip_projection=True)
             else:

--- a/src/unitaria/nodes/classical/increment.py
+++ b/src/unitaria/nodes/classical/increment.py
@@ -33,10 +33,10 @@ class Increment(Classical):
         return {"bits": self.bits}
 
     def _subspace_in(self) -> Subspace:
-        return Subspace(bits=self.bits)
+        return Subspace("#" * self.bits)
 
     def _subspace_out(self) -> Subspace:
-        return Subspace(bits=self.bits)
+        return Subspace("#" * self.bits)
 
     def is_guaranteed_unitary(self) -> bool:
         return True

--- a/src/unitaria/nodes/constants/constant_unitary.py
+++ b/src/unitaria/nodes/constants/constant_unitary.py
@@ -47,10 +47,10 @@ class ConstantUnitary(Node):
         return {"unitary": self.unitary}
 
     def _subspace_in(self) -> Subspace:
-        return Subspace(dim=self.unitary.shape[1], bits=self.bits)
+        return Subspace.from_dim(self.unitary.shape[1], bits=self.bits)
 
     def _subspace_out(self) -> Subspace:
-        return Subspace(dim=self.unitary.shape[0], bits=self.bits)
+        return Subspace.from_dim(self.unitary.shape[0], bits=self.bits)
 
     def _normalization(self) -> Subspace:
         return 1

--- a/src/unitaria/nodes/constants/constant_vector.py
+++ b/src/unitaria/nodes/constants/constant_vector.py
@@ -31,10 +31,10 @@ class ConstantVector(Node):
         return {"vec": self.vec}
 
     def _subspace_in(self) -> Subspace:
-        return Subspace(bits=0, zero_qubits=self.n_qubits)
+        return Subspace("0" * self.n_qubits)
 
     def _subspace_out(self) -> Subspace:
-        return Subspace(bits=self.n_qubits)
+        return Subspace("#" * self.n_qubits)
 
     def _normalization(self) -> float:
         return np.linalg.norm(self.vec)

--- a/src/unitaria/nodes/fourier_transform.py
+++ b/src/unitaria/nodes/fourier_transform.py
@@ -35,10 +35,10 @@ class FourierTransform(Node):
         return {"bits": self.bits}
 
     def _subspace_in(self) -> Subspace:
-        return Subspace(bits=self.bits)
+        return Subspace("#" * self.bits)
 
     def _subspace_out(self) -> Subspace:
-        return Subspace(bits=self.bits)
+        return Subspace("#" * self.bits)
 
     def _normalization(self) -> float:
         return 1

--- a/src/unitaria/nodes/multilinear_node.py
+++ b/src/unitaria/nodes/multilinear_node.py
@@ -52,7 +52,7 @@ class MultilinearNode(ProxyNode):
                 if i < len(self.apply) and self.apply[i] is not None:
                     node = self.apply[i]
                 else:
-                    node = Identity(subspace=Subspace(dim=dim))
+                    node = Identity(Subspace.from_dim(dim))
                 if apply_product is None:
                     apply_product = node
                 else:

--- a/src/unitaria/nodes/node.py
+++ b/src/unitaria/nodes/node.py
@@ -29,12 +29,12 @@ class Node(ABC):
     due to how the properties of `Node` are cached.
 
     To check that these methods are implemented correctly, use
-    `~unitaria.verifier.verify`.
+    `~unitaria.verify`.
 
     As an alternative if you can represent your custom node in terms of other
     nodes, and just want to provide a more efficient implementation of some
     of the functions -- say `compute` and `compute_adjoint` -- you can instead
-    create a subclass of `~unitaria.nodes.ProxyNode`.
+    create a subclass of `~unitaria.ProxyNode`.
     """
 
     def __init__(self, dimension_in: int, dimension_out: int):

--- a/src/unitaria/nodes/nonlinear.py
+++ b/src/unitaria/nodes/nonlinear.py
@@ -51,10 +51,10 @@ class ComponentwiseMulMultilinear(Node):
         self.subspace = subspace
 
     def _subspace_in(self) -> Subspace:
-        return Subspace(self.subspace.tensor_factors * 2)
+        return self.subspace & self.subspace
 
     def _subspace_out(self) -> Subspace:
-        return Subspace(self.subspace.tensor_factors, zero_qubits=self.subspace.total_qubits)
+        return Subspace("0" * self.subspace.total_qubits) & self.subspace
 
     def _normalization(self) -> float:
         return 1

--- a/src/unitaria/nodes/permutation/permutation.py
+++ b/src/unitaria/nodes/permutation/permutation.py
@@ -115,17 +115,19 @@ class PermuteFactors(Node):
         return 0
 
 
-def _controlled_trailing_zeros(subspace: Subspace):
+def _controlled_initial_zeros(subspace: Subspace):
     case_zero = subspace.case_zero()
     case_one = subspace.case_one()
-    return min(case_zero.trailing_zeros(), case_one.trailing_zeros())
+    return min(case_zero.initial_zeros(), case_one.initial_zeros())
 
 
 class AddZerosToControl(Node):
     """
     Operation to add zeros to both branches of a controlled subspace.
 
-    Specifically, this implements the identity for ``subspace_in = subspace & z`` and ``subspace_out = (subspace.case_zero() & z) | (subspace.case_one() & z)`` where ``z = Subspace(zero_qubits=num_zeros)``
+    Specifically, this implements the identity for ``subspace_in = z & subspace``
+    and ``subspace_out = (z & subspace.case_zero()) | (z & subspace.case_one())``
+    where ``z = Subspace("0" * num_zeros)``
     """
 
     subspace: Subspace
@@ -150,11 +152,11 @@ class AddZerosToControl(Node):
         return {"subspace": self.subspace, "num_zeros": self.num_zeros}
 
     def _subspace_in(self) -> Subspace:
-        return self.subspace & Subspace(zero_qubits=self.num_zeros)
+        return Subspace("0" * self.num_zeros) & self.subspace
 
     def _subspace_out(self) -> Subspace:
-        zeros = Subspace(zero_qubits=self.num_zeros)
-        return (self.subspace.case_zero() & zeros) | (self.subspace.case_one() & zeros)
+        zeros = Subspace("0" * self.num_zeros)
+        return (zeros & self.subspace.case_zero()) | (zeros & self.subspace.case_one())
 
     def _normalization(self) -> float:
         return 1
@@ -186,7 +188,7 @@ class SubspaceRightRotation(Node):
     """
     Identity operation rotating the root bit of the subspace.
 
-    Takes subspace of the form ``(l | m) | (r & Subspace(zero_qubits=1))`` to ``(l & Subspace(zero_qubits=1)) | (m | r)``.
+    Takes subspace of the form ``(l | m) | (Subspace("0") & r)`` to ``(Subspace("0") & l) | (m | r)``.
     """
 
     def __init__(self, subspace: Subspace):
@@ -198,15 +200,8 @@ class SubspaceRightRotation(Node):
         L = pivot.case_zero()
         M = pivot.case_one()
         R = subspace.case_one()
-        assert R.trailing_zeros() >= 1
-        self.subspace_out = Subspace(
-            [
-                ControlledSubspace(
-                    Subspace(L.tensor_factors, zero_qubits=1),
-                    Subspace([ControlledSubspace(M, Subspace(R.tensor_factors[:-1]))]),
-                )
-            ],
-        )
+        assert R.initial_zeros() >= 1
+        self.subspace_out = (Subspace("0") & L) | (M | Subspace(R.tensor_factors[:-1]))
 
         self.subspace = subspace
 
@@ -216,15 +211,8 @@ class SubspaceRightRotation(Node):
         L = subspace.case_zero()
         M = pivot.case_zero()
         R = pivot.case_one()
-        assert L.trailing_zeros() >= 1
-        subspace_in = Subspace(
-            [
-                ControlledSubspace(
-                    Subspace([ControlledSubspace(Subspace(L.tensor_factors[:-1]), M)]),
-                    Subspace(R.tensor_factors, zero_qubits=1),
-                )
-            ],
-        )
+        assert L.initial_zeros() >= 1
+        subspace_in = (Subspace(L.tensor_factors[:-1]) | M) | (Subspace("0") & R)
         return Adjoint(SubspaceRightRotation(subspace_in))
 
     def children(self) -> list[Node]:
@@ -278,11 +266,11 @@ def _rotate(subspace: Subspace, right: bool) -> Node:
     else:
         other = subspace.case_zero()
 
-    trailing_zeros = _controlled_trailing_zeros(subspace)
-    other_zeros = other.trailing_zeros()
-    if other_zeros > 1 and trailing_zeros > 0:
+    initial_zeros = _controlled_initial_zeros(subspace)
+    other_zeros = other.initial_zeros()
+    if other_zeros > 1 and initial_zeros > 0:
         permutation.append(
-            AddZerosToControl.remove_zeros(Subspace(subspace.nonzero_factors()), min(trailing_zeros, other_zeros - 1))
+            AddZerosToControl.remove_zeros(Subspace(subspace.nonzero_factors()), min(initial_zeros, other_zeros - 1))
         )
         subspace = permutation[-1].subspace_out
     elif other_zeros == 0:
@@ -294,7 +282,7 @@ def _rotate(subspace: Subspace, right: bool) -> Node:
     else:
         pivot = subspace.case_one()
 
-    pivot_zeros = pivot.trailing_zeros()
+    pivot_zeros = pivot.initial_zeros()
     if pivot_zeros != 0:
         move = AddZerosToControl(Subspace(pivot.nonzero_factors()), pivot_zeros)
         if right:

--- a/src/unitaria/nodes/permutation/permutation.py
+++ b/src/unitaria/nodes/permutation/permutation.py
@@ -5,7 +5,7 @@ from typing import Sequence
 import numpy as np
 import tequila as tq
 from unitaria.nodes.node import Node
-from unitaria.subspace import Subspace, ZeroQubit, ControlledSubspace
+from unitaria.subspace import Subspace, ZeroQubitSubspace, ControlledSubspace
 from unitaria.nodes.basic.unsafe_multiplication import UnsafeMul
 from unitaria.nodes.basic.adjoint import Adjoint
 from unitaria.nodes.basic.identity import Identity
@@ -17,7 +17,7 @@ def _move_zeros_to_end(subspace: Subspace) -> PermuteFactors:
     nonzero_factors = []
     zero_factors = []
     for i, factor in enumerate(subspace.tensor_factors):
-        if isinstance(factor, ZeroQubit):
+        if isinstance(factor, ZeroQubitSubspace):
             zero_factors.append(i)
         else:
             nonzero_factors.append(i)

--- a/src/unitaria/nodes/qsvt/qsvt.py
+++ b/src/unitaria/nodes/qsvt/qsvt.py
@@ -248,13 +248,13 @@ class QSVT(Node):
         return self.coefficients.output_normalization
 
     def _subspace_in(self) -> Subspace:
-        return Subspace(self.A.subspace_in.tensor_factors, zero_qubits=1)
+        return Subspace("0") & self.A.subspace_in
 
     def _subspace_out(self) -> Subspace:
         if self.coefficients.degree() % 2 == 0:
-            return Subspace(self.A.subspace_in.tensor_factors, zero_qubits=1)
+            return Subspace("0") & self.A.subspace_in
         else:
-            return Subspace(self.A.subspace_out.tensor_factors, zero_qubits=1)
+            return Subspace("0") & self.A.subspace_out
 
     def _compute_internal(self, input: np.ndarray, compute, compute_adjoint) -> np.ndarray:
         # This code uses self.coefficients.polynomial, which is already

--- a/src/unitaria/subspace.py
+++ b/src/unitaria/subspace.py
@@ -22,21 +22,18 @@ class Subspace:
 
     tensor_factors: list[SubspaceFactor]
 
-    def __init__(
-        self, tensor_factors: list[SubspaceFactor] = None, *, bits: int = None, dim: int = None, zero_qubits: int = 0
-    ):
-        if dim is not None:
-            assert tensor_factors is None
-            assert zero_qubits == 0
-            subspace = Subspace._from_dim(dim, bits=bits)
-            self.tensor_factors = subspace.tensor_factors
-        elif bits is not None:
-            assert tensor_factors is None
-            self.tensor_factors = [ID] * bits
-        elif tensor_factors is not None:
-            self.tensor_factors = tensor_factors
-        else:
+    def __init__(self, tensor_factors: list[SubspaceFactor] | str = []):
+        if isinstance(tensor_factors, str):
             self.tensor_factors = []
+            for c in reversed(tensor_factors):
+                if c == "0":
+                    self.tensor_factors.append(ZeroQubit())
+                elif c == "#":
+                    self.tensor_factors.append(ID)
+                else:
+                    raise ValueError()
+        else:
+            self.tensor_factors = tensor_factors
 
         for factor in self.tensor_factors:
             if not isinstance(factor, SubspaceFactor):
@@ -51,19 +48,45 @@ class Subspace:
                 simplified_factors += factor.simplify()
             else:
                 simplified_factors.append(factor)
-
-        self.tensor_factors = simplified_factors + [ZeroQubit()] * zero_qubits
+        self.tensor_factors = simplified_factors
 
     @staticmethod
-    def _from_dim(dim: int, bits: int | None = None) -> Subspace:
+    def from_dim(dim: int, bits: int | None = None) -> Subspace:
         if bits is None:
             bits = int(np.ceil(np.log2(dim)))
         if dim == 1:
-            return Subspace(bits=0, zero_qubits=bits)
+            return Subspace("0" * bits)
         min_bits = int(np.ceil(np.log2(dim)))
-        case_zero = Subspace(bits=min_bits - 1)
-        case_one = Subspace(dim=dim - 2 ** (min_bits - 1), bits=min_bits - 1)
-        return Subspace(tensor_factors=[ControlledSubspace(case_zero, case_one)], zero_qubits=bits - min_bits)
+        case_zero = Subspace("#" * (min_bits - 1))
+        case_one = Subspace.from_dim(dim - 2 ** (min_bits - 1), bits=min_bits - 1)
+        return (case_zero | case_one) & Subspace("0" * (bits - min_bits))
+
+    def __repr__(self) -> str:
+        string_constructor = ""
+        output = ""
+        for factor in self.tensor_factors:
+            if factor == ZeroQubit():
+                string_constructor = "0" + string_constructor
+            elif factor == ID:
+                string_constructor = "#" + string_constructor
+            elif isinstance(factor, ControlledSubspace):
+                if len(string_constructor) != 0:
+                    if len(output) == 0:
+                        output = f'Subspace("{string_constructor}")'
+                    else:
+                        output = f'Subspace("{string_constructor}") & {output}'
+                if len(output) == 0:
+                    output = f"({repr(factor.case_zero)} | {repr(factor.case_one)})"
+                else:
+                    output = f"({repr(factor.case_zero)} | {repr(factor.case_one)}) & {output}"
+            else:
+                raise NotImplementedError
+        if len(string_constructor) != 0:
+            if len(output) == 0:
+                output = f'Subspace("{string_constructor}")'
+            else:
+                output = f'Subspace("{string_constructor}") & {output}'
+        return output
 
     @cached_property
     def dimension(self) -> int:
@@ -93,18 +116,6 @@ class Subspace:
 
     def match_nonzero(self, other: Subspace) -> bool:
         return self.nonzero_factors() == other.nonzero_factors()
-
-    def __repr__(self) -> str:
-        trailing_zeros = self.trailing_zeros()
-        factors = self.nonzero_factors()
-        str_factors = str(len(factors))
-        for factor in factors:
-            if factor != ID:
-                str_factors = repr(factors)
-                break
-        if trailing_zeros == 0:
-            return f"Subspace({str_factors})"
-        return f"Subspace({str_factors}, zero_qubits={trailing_zeros})"
 
     def __str__(self) -> str:
         if len(self.tensor_factors) == 0:
@@ -158,24 +169,18 @@ class Subspace:
                         output += "║\n"
         return output
 
-    def is_trivial(self) -> bool:
-        """
-        Tests whether the subspace only contains the ``|0>`` state
-        """
-        return self.trailing_zeros() == len(self.tensor_factors)
-
-    def trailing_zeros(self) -> int:
+    def initial_zeros(self) -> int:
         for i in reversed(range(len(self.tensor_factors))):
             if not isinstance(self.tensor_factors[i], ZeroQubit):
                 return len(self.tensor_factors) - i - 1
         return len(self.tensor_factors)
 
     def nonzero_factors(self) -> list[SubspaceFactor]:
-        trailing_zeros = self.trailing_zeros()
-        if trailing_zeros == 0:
+        initial_zeros = self.initial_zeros()
+        if initial_zeros == 0:
             return self.tensor_factors
         else:
-            return self.tensor_factors[:-trailing_zeros]
+            return self.tensor_factors[:-initial_zeros]
 
     def test_basis(self, bits: int) -> bool:
         """
@@ -294,27 +299,27 @@ class Subspace:
                 assert result[i + 2**self.total_qubits] == 1
 
     def case_zero(self) -> Subspace:
-        trailing_zeros = self.trailing_zeros()
-        if trailing_zeros == len(self.tensor_factors):
+        initial_zeros = self.initial_zeros()
+        if initial_zeros == len(self.tensor_factors):
             return None
 
         return Subspace(
-            self.tensor_factors[: -(trailing_zeros + 1)]
-            + self.tensor_factors[-(trailing_zeros + 1)].case_zero.tensor_factors,
+            self.tensor_factors[: -(initial_zeros + 1)]
+            + self.tensor_factors[-(initial_zeros + 1)].case_zero.tensor_factors,
         )
 
     def case_one(self) -> Subspace:
-        trailing_zeros = self.trailing_zeros()
-        if trailing_zeros == len(self.tensor_factors):
+        initial_zeros = self.initial_zeros()
+        if initial_zeros == len(self.tensor_factors):
             return None
 
         return Subspace(
-            self.tensor_factors[: -(trailing_zeros + 1)]
-            + self.tensor_factors[-(trailing_zeros + 1)].case_one.tensor_factors,
+            self.tensor_factors[: -(initial_zeros + 1)]
+            + self.tensor_factors[-(initial_zeros + 1)].case_one.tensor_factors,
         )
 
     def __and__(self, other: Subspace) -> Subspace:
-        return Subspace(self.tensor_factors + other.tensor_factors)
+        return Subspace(other.tensor_factors + self.tensor_factors)
 
     def __or__(self, other: Subspace) -> Subspace:
         return Subspace([ControlledSubspace(self, other)])
@@ -454,4 +459,4 @@ class ControlledSubspace(SubspaceFactor):
         return max(self.case_zero.clean_ancilla_count(), self.case_one.clean_ancilla_count())
 
 
-ID = ControlledSubspace(Subspace(tensor_factors=[]), Subspace(tensor_factors=[]))
+ID = ControlledSubspace(Subspace([]), Subspace([]))

--- a/src/unitaria/subspace.py
+++ b/src/unitaria/subspace.py
@@ -15,9 +15,98 @@ from unitaria.util import cached_property
 
 
 class Subspace:
-    # TODO: More documentation
     """
     Subspace of the statespace of a number of qubits.
+
+    In ``unitaria``, subspaces are always the span of vectors in the
+    computational basis, so this object just stores the indices of
+    these computational basis states.
+
+    Constructors
+    ------------
+
+    If you just need a subspace with a given dimension, use `Subspace.from_dim`.
+
+    Otherwise, the preferred way to construct subspaces is using the string
+    constructor. It takes a string consisting of ``#`` and ``0``, respectively
+    representing a bit that can be in either state, or a bit that should be in
+    its ``0`` state.
+
+        >>> import unitaria as ut
+        >>> ut.Subspace("#").enumerate_basis()
+        array([0, 1], dtype=int32)
+        >>> ut.Subspace("0").enumerate_basis()
+        array([0], dtype=int32)
+
+    Alternatively, the subspace can be constructed according to its internal
+    representation, see below.
+
+    When given multiple symbols, they are combined using tensor products as
+    expected.
+
+        >>> import unitaria as ut
+        >>> ut.Subspace("##0").enumerate_basis()
+        array([0, 2, 4, 6], dtype=int32)
+
+    Subspaces can be combined using the operators ``&`` (tensor product) or
+    ``|`` direct sum.
+
+        >>> import unitaria as ut
+        >>> (ut.Subspace("#") & ut.Subspace("0")).enumerate_basis()
+        array([0, 2], dtype=int32)
+        >>> (ut.Subspace("#") | ut.Subspace("0")).enumerate_basis()
+        array([0, 1, 2], dtype=int32)
+
+    Intutively, with the ``|`` operator the highest bit decides the subspace
+    of the lower bits. So in the example above, when the highes bit is ``0``
+    then the lower bit can either be ``0`` or ``1``, but when the highest bit
+    is ``1`` then the lower bit has to be ``0``.
+
+    Reading the subspace
+    --------------------
+
+    The method `enumerate_basis` gives a list of all the indices in the
+    subspace, but this should typically only be used for verification. It
+    does not make sense as part of an efficient quantum algorithm, since the
+    complexity of `enumerate_basis` is always linear in the dimension.
+
+    The methods `test_basis` on the other hand is efficient. It checks whether a
+    given index is in the subspace.
+
+    The dimension of the subspace can be obtained using `Subspace.dimension`.
+    The dimension of the super-space can be caluclated from the number of
+    qubits, which is stored in `Subspace.total_qubits`. Specifically, the
+    super-space dimension is ``2 ** subspace.total_qubits``.
+
+        >>> import unitaria as ut
+        >>> ut.Subspace("0#0").dimension
+        2
+        >>> ut.Subspace("0#0").total_qubits
+        3
+
+    Internal representation
+    -----------------------
+
+    Typically one does not need to inspect `Subspace` objects, most properties
+    can be derived using its methods. Internally, the object stores a
+    decomposition of the subspace into tensor factors. This decomposition is
+    simplified at construction and so does not have to correspond to the factors
+    that are put in. Any of the factors can be either
+
+    * a `ZeroQubitSubspace`, indicating the subspace of the space of one
+      qubit, where this qubit is zero, or
+    * a `ControlledSubspace`, indicating that a subspace, where the
+      most siginificant bit determines the subspaces of the lower bits.
+      These subspaces are given by `ControlledSubspace.case_zero` and
+      `ControlledSubspace.case_one`. With this one can also construct the full
+      subspace of a qubit by `ControlledSubspace(Subspace(), Subspace())`.
+      (For this there is also the constant `~unitaria.FullQubitSubspace`.)
+
+    :param tensor_factors: List or string of factors making up the subspace, see below.
+
+    :raises ValueError:
+        If a string with characters other than ``#`` or ``0`` is given or a list
+        with anything that is not a `SubspaceFactor`
     """
 
     tensor_factors: list[SubspaceFactor]
@@ -27,9 +116,9 @@ class Subspace:
             self.tensor_factors = []
             for c in reversed(tensor_factors):
                 if c == "0":
-                    self.tensor_factors.append(ZeroQubit())
+                    self.tensor_factors.append(ZeroQubitSubspace())
                 elif c == "#":
-                    self.tensor_factors.append(ID)
+                    self.tensor_factors.append(FullQubitSubspace)
                 else:
                     raise ValueError()
         else:
@@ -37,7 +126,7 @@ class Subspace:
 
         for factor in self.tensor_factors:
             if not isinstance(factor, SubspaceFactor):
-                if factor is ZeroQubit:
+                if factor is ZeroQubitSubspace:
                     raise ValueError(
                         f"{factor} is not a valid factor in a Subspace. Use `ZeroQubit()` instead of `ZeroQubit`"
                     )
@@ -62,12 +151,14 @@ class Subspace:
         return (case_zero | case_one) & Subspace("0" * (bits - min_bits))
 
     def __repr__(self) -> str:
+        if len(self.tensor_factors) == 0:
+            return "Subspace()"
         string_constructor = ""
         output = ""
         for factor in self.tensor_factors:
-            if factor == ZeroQubit():
+            if factor == ZeroQubitSubspace():
                 string_constructor = "0" + string_constructor
-            elif factor == ID:
+            elif factor == FullQubitSubspace:
                 string_constructor = "#" + string_constructor
             elif isinstance(factor, ControlledSubspace):
                 if len(string_constructor) != 0:
@@ -171,7 +262,7 @@ class Subspace:
 
     def initial_zeros(self) -> int:
         for i in reversed(range(len(self.tensor_factors))):
-            if not isinstance(self.tensor_factors[i], ZeroQubit):
+            if not isinstance(self.tensor_factors[i], ZeroQubitSubspace):
                 return len(self.tensor_factors) - i - 1
         return len(self.tensor_factors)
 
@@ -202,7 +293,7 @@ class Subspace:
                     if not result:
                         return False
                     bits = bits >> (num_qubits + 1)
-                case ZeroQubit():
+                case ZeroQubitSubspace():
                     if bits & 1 != 0:
                         return False
                     bits = bits >> 1
@@ -241,14 +332,14 @@ class Subspace:
         circuit = Circuit()
 
         for factor in self.tensor_factors:
-            if isinstance(factor, ZeroQubit):
+            if isinstance(factor, ZeroQubitSubspace):
                 # Zero qubits already behave like flag qubits, so we only need to toggle it
                 circuit += tq.gates.X(target=target[index])
                 intermediate_flags.append(target[index])
                 index += 1
                 continue
 
-            if factor == ID:
+            if factor == FullQubitSubspace:
                 # No need to do anything here
                 index += 1
                 continue
@@ -344,7 +435,7 @@ class SubspaceFactor(ABC):
 
 
 @dataclass(frozen=True)
-class ZeroQubit(SubspaceFactor):
+class ZeroQubitSubspace(SubspaceFactor):
     def total_qubits(self) -> int:
         return 1
 
@@ -355,7 +446,7 @@ class ZeroQubit(SubspaceFactor):
         return "0"
 
 
-@dataclass(frozen=True, repr=False)
+@dataclass(frozen=True)
 class ControlledSubspace(SubspaceFactor):
     """
     SubspaceFactor where the most significant qubit determines the subspace
@@ -372,11 +463,6 @@ class ControlledSubspace(SubspaceFactor):
 
     def __post_init__(self):
         assert self.case_zero.total_qubits == self.case_one.total_qubits
-
-    def __repr__(self) -> str:
-        if self == ID:
-            return "ID"
-        return f"ControlledSubspace(case_zero={repr(self.case_zero)}, case_one={repr(self.case_one)})"
 
     def total_qubits(self) -> int:
         return 1 + self.case_zero.total_qubits
@@ -418,8 +504,8 @@ class ControlledSubspace(SubspaceFactor):
         qubits, this common part can be factored out. E.g.
 
             >>> import unitaria as ut
-            >>> ut.ControlledSubspace(ut.Subspace(bits=2), ut.Subspace(bits=1, zero_qubits=1)).simplify()
-            [ID, ControlledSubspace(case_zero=Subspace(1), case_one=Subspace(0, zero_qubits=1))]
+            >>> ut.ControlledSubspace(ut.Subspace("##"), ut.Subspace("0#")).simplify()
+            [ControlledSubspace(case_zero=Subspace(), case_one=Subspace()), ControlledSubspace(case_zero=Subspace("#"), case_one=Subspace("0"))]
         """
         min_len = min(len(self.case_zero.tensor_factors), len(self.case_one.tensor_factors))
         for i in range(min_len):
@@ -459,4 +545,4 @@ class ControlledSubspace(SubspaceFactor):
         return max(self.case_zero.clean_ancilla_count(), self.case_one.clean_ancilla_count())
 
 
-ID = ControlledSubspace(Subspace([]), Subspace([]))
+FullQubitSubspace = ControlledSubspace(Subspace([]), Subspace([]))

--- a/tests/nodes/test_amplification.py
+++ b/tests/nodes/test_amplification.py
@@ -4,9 +4,7 @@ import unitaria as ut
 
 def test_grover_amplification():
     node = ut.ConstantVector(np.array([1 / 2, 1 / 2, 1 / 2, 1 / 2]))
-    proj = ut.Projection(
-        subspace_from=ut.Subspace(bits=2, zero_qubits=0), subspace_to=ut.Subspace(bits=0, zero_qubits=2)
-    )
+    proj = ut.Projection(subspace_from=ut.Subspace("##"), subspace_to=ut.Subspace("00"))
     node = proj @ node
 
     amplified = ut.GroverAmplification(node, 0)
@@ -23,9 +21,7 @@ def test_grover_amplification():
 
 def test_fixed_point_amplification():
     node = ut.ConstantVector(np.array([1 / 2, 1 / 2, 1 / 2, 1 / 2]))
-    proj = ut.Projection(
-        subspace_from=ut.Subspace(bits=2, zero_qubits=0), subspace_to=ut.Subspace(bits=0, zero_qubits=2)
-    )
+    proj = ut.Projection(subspace_from=ut.Subspace("##"), subspace_to=ut.Subspace("00"))
     node = proj @ node
 
     # Test with known norm
@@ -48,9 +44,9 @@ def test_linear_amplification():
         ut.ConstantUnitary(rot_matrix(np.arccos(0.2))) | ut.ConstantUnitary(rot_matrix(np.arccos(0.3)))
     )
     node = (
-        ut.Projection(subspace_from=ut.Subspace(bits=3), subspace_to=ut.Subspace([ut.ZeroQubit(), ut.ID, ut.ID]))
+        ut.Projection(subspace_from=ut.Subspace("###"), subspace_to=ut.Subspace("##0"))
         @ A
-        @ ut.Projection(subspace_from=ut.Subspace([ut.ZeroQubit(), ut.ID, ut.ID]), subspace_to=ut.Subspace(bits=3))
+        @ ut.Projection(subspace_from=ut.Subspace("##0"), subspace_to=ut.Subspace("###"))
     )
     amplified = ut.LinearAmplification(node, 2.0, 0.4, 0.1)
     ut.verify(amplified, np.diag(np.array([0.0, 0.2, 0.4, 0.6])), atol=0.1, check_adjoint=False)

--- a/tests/nodes/test_basic_ops.py
+++ b/tests/nodes/test_basic_ops.py
@@ -3,7 +3,7 @@ import unitaria as ut
 
 def test_tensor():
     A = ut.Increment(bits=1)
-    B = ut.Identity(subspace=ut.Subspace(bits=1))
+    B = ut.Identity(ut.Subspace("#"))
 
     ut.verify((A & B))
     ut.verify((A & A))

--- a/tests/nodes/test_block_concatenation.py
+++ b/tests/nodes/test_block_concatenation.py
@@ -2,14 +2,14 @@ import unitaria as ut
 
 
 def test_block_horizontal():
-    A = ut.Identity(subspace=ut.Subspace(bits=1))
+    A = ut.Identity(ut.Subspace("#"))
     B = ut.Increment(bits=1)
     ut.verify(ut.BlockHorizontal(A, B))
     ut.verify(ut.BlockHorizontal(B, A))
 
 
 def test_block_vertical():
-    A = ut.Identity(subspace=ut.Subspace(bits=1))
+    A = ut.Identity(ut.Subspace("#"))
     B = ut.Increment(bits=1)
     ut.verify(ut.BlockVertical(A, B))
     ut.verify(ut.BlockVertical(B, A))

--- a/tests/nodes/test_block_encoding.py
+++ b/tests/nodes/test_block_encoding.py
@@ -4,8 +4,8 @@ import unitaria as ut
 
 def create_block_encoding():
     # initialize a block encoding with a simple X gate on the first qubit
-    subspace_in = ut.Subspace(bits=1, zero_qubits=1)
-    subspace_out = ut.Subspace(bits=2)
+    subspace_in = ut.Subspace("0#")
+    subspace_out = ut.Subspace("##")
     tequila_circuit = tq.QCircuit()
     tequila_circuit += tq.gates.X(0)
     tequila_circuit.n_qubits = 2

--- a/tests/nodes/test_controlled_ops.py
+++ b/tests/nodes/test_controlled_ops.py
@@ -2,7 +2,7 @@ import unitaria as ut
 
 
 def test_block_diagonal():
-    A = ut.Identity(subspace=ut.Subspace(bits=2, zero_qubits=1))
+    A = ut.Identity(ut.Subspace("0##"))
     B = ut.Increment(bits=2)
 
     D = A | B
@@ -12,7 +12,7 @@ def test_block_diagonal():
 
 
 def test_block_diagonal_with_permutation():
-    A = ut.Identity(subspace=ut.Subspace(bits=2))
+    A = ut.Identity(ut.Subspace("##"))
     B = ut.Increment(bits=2)
 
     D = A | B

--- a/tests/nodes/test_identity.py
+++ b/tests/nodes/test_identity.py
@@ -2,7 +2,7 @@ import unitaria as ut
 
 
 def test_identity():
-    Id = ut.Identity(subspace=ut.Subspace(bits=1))
+    Id = ut.Identity(ut.Subspace("#"))
     ut.verify(Id)
-    Id = ut.Identity(subspace=ut.Subspace(bits=0))
+    Id = ut.Identity(ut.Subspace())
     ut.verify(Id)

--- a/tests/nodes/test_measurement.py
+++ b/tests/nodes/test_measurement.py
@@ -4,7 +4,7 @@ import pytest
 
 
 def test_sum_1_norm():
-    identity = ut.Identity(bits=1)
+    identity = ut.Identity(ut.Subspace("#"))
     z_pauli_matrix = ut.ConstantUnitary(np.array([[1, 0], [0, -1]]))
     sum_1 = 0.75 * identity + 0.25 * z_pauli_matrix
     assert pytest.approx(sum_1.simulate_norm(input=0)) == 1.0
@@ -12,7 +12,7 @@ def test_sum_1_norm():
 
 
 def test_sum_2_norm():
-    identity = ut.Identity(bits=1)
+    identity = ut.Identity(ut.Subspace("#"))
     z_pauli_matrix = ut.ConstantUnitary(np.array([[1, 0], [0, -1]]))
     sum_2 = 0.5 * identity + 0.5 * z_pauli_matrix
     assert pytest.approx(sum_2.simulate_norm(input=0)) == 1.0

--- a/tests/nodes/test_nonlinear.py
+++ b/tests/nodes/test_nonlinear.py
@@ -3,13 +3,9 @@ import numpy as np
 
 
 def test_componentwise_mul():
-    ut.verify(ut.ComponentwiseMul(ut.Subspace(bits=1)))
-    ut.verify(ut.ComponentwiseMul(ut.Subspace(bits=1, zero_qubits=1)))
-    ut.verify(
-        ut.ComponentwiseMul(
-            ut.Subspace([ut.ID, ut.ControlledSubspace(ut.Subspace(bits=1), ut.Subspace(bits=0, zero_qubits=1))])
-        )
-    )
+    ut.verify(ut.ComponentwiseMul(ut.Subspace("#")))
+    ut.verify(ut.ComponentwiseMul(ut.Subspace("0#")))
+    ut.verify(ut.ComponentwiseMul((ut.Subspace("#") | ut.Subspace("0")) & ut.Subspace("#")))
 
 
 def test_componentwise_mul_partial():

--- a/tests/nodes/test_permutation.py
+++ b/tests/nodes/test_permutation.py
@@ -12,28 +12,26 @@ from unitaria.nodes.permutation.permutation import (
 
 
 def test_find_permutation_trivial():
-    ut.verify(permute(ut.Subspace(bits=0), ut.Subspace(bits=0)))
-    ut.verify(permute(ut.Subspace(bits=0, zero_qubits=1), ut.Subspace(bits=0, zero_qubits=1)))
-    ut.verify(permute(ut.Subspace(bits=1), ut.Subspace(bits=1)))
-    ut.verify(permute(ut.Subspace(bits=1, zero_qubits=1), ut.Subspace(bits=1, zero_qubits=1)))
-    ut.verify(permute(ut.Subspace(bits=1, zero_qubits=2), ut.Subspace(bits=1, zero_qubits=2)))
-    c = ut.ControlledSubspace(ut.Subspace(bits=1), ut.Subspace(bits=0, zero_qubits=1))
-    ut.verify(permute(ut.Subspace([c]), ut.Subspace([c])))
+    ut.verify(permute(ut.Subspace(), ut.Subspace()))
+    ut.verify(permute(ut.Subspace("0"), ut.Subspace("0")))
+    ut.verify(permute(ut.Subspace("#"), ut.Subspace("#")))
+    ut.verify(permute(ut.Subspace("0#"), ut.Subspace("0#")))
+    ut.verify(permute(ut.Subspace("00#"), ut.Subspace("00#")))
+    c = ut.Subspace("#") | ut.Subspace("0")
+    ut.verify(permute(c, c))
 
-    ut.verify(permute(ut.Subspace(bits=0), ut.Subspace(bits=0, zero_qubits=1)))
-    ut.verify(permute(ut.Subspace(bits=1), ut.Subspace(bits=1, zero_qubits=1)))
-    ut.verify(permute(ut.Subspace([c]), ut.Subspace([c], zero_qubits=1)))
+    ut.verify(permute(ut.Subspace(), ut.Subspace("0")))
+    ut.verify(permute(ut.Subspace("#"), ut.Subspace("0#")))
+    ut.verify(permute(c, ut.Subspace("0") & c))
 
 
 def test_find_permutation_matching_partitioning():
-    ut.verify(permute(ut.Subspace([ut.ZeroQubit(), ut.ID]), ut.Subspace(bits=1)))
-    ut.verify(permute(ut.Subspace(bits=1), ut.Subspace([ut.ZeroQubit(), ut.ID])))
+    ut.verify(permute(ut.Subspace("#0"), ut.Subspace("#")))
+    ut.verify(permute(ut.Subspace("#"), ut.Subspace("#0")))
 
 
 def test_add_zeros_to_control():
-    subspace_in = ut.Subspace(
-        [ut.ControlledSubspace(ut.Subspace(bits=1, zero_qubits=2), ut.Subspace(bits=0, zero_qubits=3))]
-    )
+    subspace_in = ut.Subspace("00#") | ut.Subspace("000")
     ut.verify(AddZerosToControl(subspace_in, 0))
     ut.verify(AddZerosToControl(subspace_in, 1))
     ut.verify(AddZerosToControl(subspace_in, 2))
@@ -42,45 +40,19 @@ def test_add_zeros_to_control():
 
 
 def test_subspace_rotation():
-    ut.verify(_rotate(ut.Subspace(bits=2), False))
-    ut.verify(_rotate(ut.Subspace(bits=2), True))
-    subspace = ut.Subspace([ut.ControlledSubspace(ut.Subspace(bits=1), ut.Subspace(bits=0, zero_qubits=1))])
+    ut.verify(_rotate(ut.Subspace("##"), False))
+    ut.verify(_rotate(ut.Subspace("##"), True))
+    subspace = ut.Subspace("#") | ut.Subspace("0")
     ut.verify(_rotate(subspace, True))
-    subspace = ut.Subspace([ut.ControlledSubspace(ut.Subspace(bits=0, zero_qubits=1), ut.Subspace(bits=1))])
+    subspace = ut.Subspace("0") | ut.Subspace("#")
     ut.verify(_rotate(subspace, False))
-    subspace = ut.Subspace(
-        [
-            ut.ID,
-            ut.ControlledSubspace(
-                ut.Subspace([ut.ZeroQubit(), ut.ID]),
-                ut.Subspace([ut.ControlledSubspace(ut.Subspace(bits=0, zero_qubits=1), ut.Subspace(bits=1))]),
-            ),
-        ]
-    )
+    subspace = (ut.Subspace("#0") | (ut.Subspace("0") | ut.Subspace("#"))) & ut.Subspace("#")
     ut.verify(_rotate(subspace, True))
     ut.verify(_rotate(subspace, False))
-    subspace = ut.Subspace(
-        [
-            ut.ID,
-            ut.ControlledSubspace(
-                ut.Subspace([ut.ZeroQubit(), ut.ID]),
-                ut.Subspace([ut.ControlledSubspace(ut.Subspace(bits=0, zero_qubits=1), ut.Subspace(bits=1))]),
-            ),
-        ],
-        zero_qubits=1,
-    )
+    subspace = ut.Subspace("0") & (ut.Subspace("#0") | (ut.Subspace("0") | ut.Subspace("#"))) & ut.Subspace("#")
     ut.verify(_rotate(subspace, True))
     ut.verify(_rotate(subspace, False))
-    subspace = ut.Subspace(
-        [
-            ut.ID,
-            ut.ControlledSubspace(
-                ut.Subspace([ut.ZeroQubit(), ut.ID]),
-                ut.Subspace([ut.ControlledSubspace(ut.Subspace(bits=0, zero_qubits=1), ut.Subspace(bits=1))]),
-            ),
-        ],
-        zero_qubits=3,
-    )
+    subspace = ut.Subspace("000") & (ut.Subspace("#0") | (ut.Subspace("0") | ut.Subspace("#"))) & ut.Subspace("#")
     ut.verify(_rotate(subspace, True))
     ut.verify(_rotate(subspace, False))
 
@@ -88,17 +60,10 @@ def test_subspace_rotation():
 @pytest.mark.parametrize(
     "subspace",
     [
-        ut.Subspace(bits=2),
-        ut.Subspace(bits=3),
-        ut.Subspace([ut.ControlledSubspace(ut.Subspace(bits=0, zero_qubits=1), ut.Subspace(bits=1))]),
-        ut.Subspace(
-            [
-                ut.ControlledSubspace(
-                    ut.Subspace([ut.ID, ut.ZeroQubit(), ut.ZeroQubit()]),
-                    ut.Subspace([ut.ZeroQubit(), ut.ID, ut.ZeroQubit()]),
-                ),
-            ]
-        ),
+        ut.Subspace("##"),
+        ut.Subspace("###"),
+        ut.Subspace("0") | ut.Subspace("#"),
+        (ut.Subspace("00#") | ut.Subspace("0#0")),
     ],
 )
 def test_rotate_to(subspace):
@@ -107,88 +72,86 @@ def test_rotate_to(subspace):
 
 
 def test_1_simple_rotation():
-    a = ut.Subspace(bits=1)
-    a1 = ut.Subspace(bits=1, zero_qubits=1)
-    b = ut.Subspace([ut.ControlledSubspace(a, a)])
-    c = ut.Subspace([ut.ControlledSubspace(b, a1)])
-    d = ut.Subspace([ut.ControlledSubspace(a1, b)])
+    a = ut.Subspace("#")
+    a1 = ut.Subspace("0#")
+    b = a | a
+    c = b | a1
+    d = a1 | b
     ut.verify(permute(d, c))
     ut.verify(permute(c, d))
 
 
 def test_2_simple_rotations():
-    a = ut.Subspace(bits=2)
+    a = ut.Subspace("##")
 
     # Left
-    b1 = ut.Subspace(bits=1)
-    b2 = ut.Subspace([ut.ControlledSubspace(b1, ut.Subspace(bits=0, zero_qubits=1))])
-    b3 = ut.Subspace([ut.ControlledSubspace(b2, ut.Subspace(bits=0, zero_qubits=2))])
+    b1 = ut.Subspace("#")
+    b2 = b1 | ut.Subspace("0")
+    b3 = b2 | ut.Subspace("00")
     ut.verify(permute(a, b3))
     ut.verify(permute(b3, a))
 
     # Right
-    b1 = ut.Subspace(bits=1)
-    b2 = ut.Subspace([ut.ControlledSubspace(ut.Subspace(bits=0, zero_qubits=1), b1)])
-    b3 = ut.Subspace([ut.ControlledSubspace(ut.Subspace(bits=0, zero_qubits=2), b2)])
+    b1 = ut.Subspace("#")
+    b2 = ut.Subspace("0") | b1
+    b3 = ut.Subspace("00") | b2
     ut.verify(permute(a, b3))
     ut.verify(permute(b3, a))
 
 
 def test_double_rotation_left_right():
-    a = ut.Subspace(bits=2)
+    a = ut.Subspace("##")
 
-    b1 = ut.Subspace(bits=1)
-    b2 = ut.Subspace([ut.ControlledSubspace(ut.Subspace(bits=0, zero_qubits=1), b1)])
-    b3 = ut.Subspace([ut.ControlledSubspace(b2, ut.Subspace(bits=0, zero_qubits=2))])
+    b1 = ut.Subspace("#")
+    b2 = ut.Subspace("0") | b1
+    b3 = b2 | ut.Subspace("00")
     ut.verify(permute(a, b3))
 
 
 def test_double_rotation_right_left():
-    a = ut.Subspace(bits=2)
+    a = ut.Subspace("##")
 
-    b1 = ut.Subspace(bits=1)
-    b2 = ut.Subspace([ut.ControlledSubspace(b1, ut.Subspace(bits=0, zero_qubits=1))])
-    b3 = ut.Subspace([ut.ControlledSubspace(ut.Subspace(bits=0, zero_qubits=2), b2)])
+    b1 = ut.Subspace("#")
+    b2 = b1 | ut.Subspace("0")
+    b3 = ut.Subspace("00") | b2
     ut.verify(permute(a, b3))
 
 
 def test_permute_registers():
-    ut.verify(PermuteFactors(ut.Subspace(bits=1), [0]))
-    ut.verify(PermuteFactors(ut.Subspace(bits=2), [0, 1]))
-    ut.verify(PermuteFactors(ut.Subspace(bits=2), [1, 0]))
-    ut.verify(PermuteFactors(ut.Subspace(bits=3), [0, 1, 2]))
-    ut.verify(PermuteFactors(ut.Subspace(bits=3), [0, 2, 1]))
-    ut.verify(PermuteFactors(ut.Subspace(bits=3), [1, 0, 2]))
-    ut.verify(PermuteFactors(ut.Subspace(bits=3), [1, 2, 0]))
-    ut.verify(PermuteFactors(ut.Subspace(bits=3), [2, 0, 1]))
-    ut.verify(PermuteFactors(ut.Subspace(bits=3), [2, 1, 0]))
+    ut.verify(PermuteFactors(ut.Subspace("#"), [0]))
+    ut.verify(PermuteFactors(ut.Subspace("##"), [0, 1]))
+    ut.verify(PermuteFactors(ut.Subspace("##"), [1, 0]))
+    ut.verify(PermuteFactors(ut.Subspace("###"), [0, 1, 2]))
+    ut.verify(PermuteFactors(ut.Subspace("###"), [0, 2, 1]))
+    ut.verify(PermuteFactors(ut.Subspace("###"), [1, 0, 2]))
+    ut.verify(PermuteFactors(ut.Subspace("###"), [1, 2, 0]))
+    ut.verify(PermuteFactors(ut.Subspace("###"), [2, 0, 1]))
+    ut.verify(PermuteFactors(ut.Subspace("###"), [2, 1, 0]))
 
 
 def test_find_matching_partitioning():
-    assert _find_matching_partitioning(ut.Subspace(bits=0), ut.Subspace(bits=0)) == []
-    assert _find_matching_partitioning(ut.Subspace(bits=1), ut.Subspace(bits=1)) == [
-        (ut.Subspace(bits=1), ut.Subspace(bits=1))
-    ]
-    assert _find_matching_partitioning(ut.Subspace(bits=2), ut.Subspace(bits=2)) == [
-        (ut.Subspace(bits=1), ut.Subspace(bits=1)),
-        (ut.Subspace(bits=1), ut.Subspace(bits=1)),
+    assert _find_matching_partitioning(ut.Subspace(), ut.Subspace()) == []
+    assert _find_matching_partitioning(ut.Subspace("#"), ut.Subspace("#")) == [(ut.Subspace("#"), ut.Subspace("#"))]
+    assert _find_matching_partitioning(ut.Subspace("##"), ut.Subspace("##")) == [
+        (ut.Subspace("#"), ut.Subspace("#")),
+        (ut.Subspace("#"), ut.Subspace("#")),
     ]
 
-    c = ut.ControlledSubspace(ut.Subspace(bits=1), ut.Subspace(bits=1))
-    assert _find_matching_partitioning(ut.Subspace([c]), ut.Subspace(bits=2)) == [
-        (ut.Subspace(bits=1), ut.Subspace(bits=1)),
-        (ut.Subspace(bits=1), ut.Subspace(bits=1)),
+    c = ut.Subspace("#") | ut.Subspace("#")
+    assert _find_matching_partitioning(c, ut.Subspace("##")) == [
+        (ut.Subspace("#"), ut.Subspace("#")),
+        (ut.Subspace("#"), ut.Subspace("#")),
     ]
-    assert _find_matching_partitioning(ut.Subspace(bits=2), ut.Subspace([c])) == [
-        (ut.Subspace(bits=1), ut.Subspace(bits=1)),
-        (ut.Subspace(bits=1), ut.Subspace(bits=1)),
+    assert _find_matching_partitioning(ut.Subspace("##"), c) == [
+        (ut.Subspace("#"), ut.Subspace("#")),
+        (ut.Subspace("#"), ut.Subspace("#")),
     ]
-    c = ut.ControlledSubspace(ut.Subspace(bits=1), ut.Subspace(bits=0, zero_qubits=1))
-    assert _find_matching_partitioning(ut.Subspace([c]), ut.Subspace([c])) == [(ut.Subspace([c]), ut.Subspace([c]))]
-    assert _find_matching_partitioning(ut.Subspace([ut.ID, c]), ut.Subspace([c, ut.ID])) == [
-        (ut.Subspace([ut.ID, c]), ut.Subspace([c, ut.ID]))
+    c = ut.Subspace("#") | ut.Subspace("0")
+    assert _find_matching_partitioning(c, c) == [(c, c)]
+    assert _find_matching_partitioning(c & ut.Subspace("#"), ut.Subspace("#") & c) == [
+        (c & ut.Subspace("#"), ut.Subspace("#") & c)
     ]
-    assert _find_matching_partitioning(ut.Subspace([ut.ID, c]), ut.Subspace([ut.ID, c])) == [
-        (ut.Subspace(bits=1), ut.Subspace(bits=1)),
-        (ut.Subspace([c]), ut.Subspace([c])),
+    assert _find_matching_partitioning(c & ut.Subspace("#"), c & ut.Subspace("#")) == [
+        (ut.Subspace("#"), ut.Subspace("#")),
+        (c, c),
     ]

--- a/tests/nodes/test_projection.py
+++ b/tests/nodes/test_projection.py
@@ -2,6 +2,6 @@ import unitaria as ut
 
 
 def test_projection():
-    ut.verify(ut.Projection(ut.Subspace(bits=1), ut.Subspace(bits=1)))
-    ut.verify(ut.Projection(ut.Subspace(bits=2), ut.Subspace(bits=1, zero_qubits=1)))
-    ut.verify(ut.Projection(ut.Subspace(bits=1, zero_qubits=1), ut.Subspace(bits=2)))
+    ut.verify(ut.Projection(ut.Subspace("#"), ut.Subspace("#")))
+    ut.verify(ut.Projection(ut.Subspace("##"), ut.Subspace("0#")))
+    ut.verify(ut.Projection(ut.Subspace("0#"), ut.Subspace("##")))

--- a/tests/nodes/test_pseudoinverse.py
+++ b/tests/nodes/test_pseudoinverse.py
@@ -11,9 +11,9 @@ def test_pseudoinverse():
         ut.ConstantUnitary(rot_matrix(np.pi / 4)) | ut.ConstantUnitary(rot_matrix(0.0))
     )
     B = (
-        ut.Projection(subspace_from=ut.Subspace(bits=3), subspace_to=ut.Subspace([ut.ZeroQubit(), ut.ID, ut.ID]))
+        ut.Projection(subspace_from=ut.Subspace("###"), subspace_to=ut.Subspace("##0"))
         @ A
-        @ ut.Projection(subspace_from=ut.Subspace([ut.ZeroQubit(), ut.ID, ut.ID]), subspace_to=ut.Subspace(bits=3))
+        @ ut.Projection(subspace_from=ut.Subspace("##0"), subspace_to=ut.Subspace("###"))
     )
     B_inv = ut.Pseudoinverse(B, condition=10.0, tolerance=0.1)
     C = B_inv @ B  # should be roughly a projector on all but the first basis states
@@ -23,9 +23,9 @@ def test_pseudoinverse():
 def test_pseudoinverse_normalization():
     A = 2 * ut.ConstantUnitary(rot_matrix(np.pi / 3))
     B = (
-        ut.Projection(subspace_from=ut.Subspace(bits=1), subspace_to=ut.Subspace([ut.ZeroQubit()]))
+        ut.Projection(subspace_from=ut.Subspace("#"), subspace_to=ut.Subspace("0"))
         @ A
-        @ ut.Projection(subspace_from=ut.Subspace([ut.ZeroQubit()]), subspace_to=ut.Subspace(bits=1))
+        @ ut.Projection(subspace_from=ut.Subspace("0"), subspace_to=ut.Subspace("#"))
     )
     B_inv = ut.Pseudoinverse(B, condition=2.0, tolerance=0.1)
     C = B_inv @ B

--- a/tests/nodes/test_qsvt.py
+++ b/tests/nodes/test_qsvt.py
@@ -51,9 +51,9 @@ def test_qsvt_coefficients():
 def test_qsvt_grover():
     # Define v so it has some subnormalization
     v = (
-        ut.Projection(ut.Subspace(bits=1), ut.Subspace(bits=0, zero_qubits=1))
+        ut.Projection(ut.Subspace("#"), ut.Subspace("0"))
         @ ut.ConstantUnitary(2 ** (-1 / 2) * np.array([[1, 1], [1, -1]]))
-        @ ut.Projection(ut.Subspace(bits=0, zero_qubits=1), ut.Subspace(bits=1))
+        @ ut.Projection(ut.Subspace("0"), ut.Subspace("#"))
     )
     A = ut.QSVT(v, np.array(4 * [np.pi]), "angles")
     ut.verify(A)
@@ -61,9 +61,7 @@ def test_qsvt_grover():
 
 def test_qsvt_with_ancillas():
     # Define v so it has some subnormalization
-    A = ut.Identity(
-        subspace=ut.Subspace([ut.ID, ut.ControlledSubspace(ut.Subspace(bits=1), ut.Subspace(bits=0, zero_qubits=1))])
-    )
+    A = ut.Identity((ut.Subspace("#") | ut.Subspace("0")) & ut.Subspace("#"))
     assert A.subspace.total_qubits + A.subspace.clean_ancilla_count() > 2
     B = ut.QSVT(A, np.array(4 * [np.pi]), "angles")
     ut.verify(B)

--- a/tests/nodes/test_ring.py
+++ b/tests/nodes/test_ring.py
@@ -2,7 +2,7 @@ import unitaria as ut
 
 
 def test_add():
-    A = ut.Identity(subspace=ut.Subspace(bits=1, zero_qubits=1))
+    A = ut.Identity(ut.Subspace("0#"))
     B = ut.Increment(bits=1)
 
     D = A + B

--- a/tests/test_gaussian_conv.py
+++ b/tests/test_gaussian_conv.py
@@ -8,12 +8,12 @@ def test_1d_gaussian_conv():
     gaussian = np.exp(-(x**2))
     prep = ut.ConstantVector(np.append([0], np.sqrt(gaussian)))
     conv = (
-        ut.Projection(subspace_from=ut.Subspace(bits=4), subspace_to=ut.Subspace(bits=3, zero_qubits=1))
-        @ (ut.Adjoint(prep) & ut.Identity(subspace=ut.Subspace(bits=4)))
-        @ (ut.Identity(subspace=ut.Subspace(bits=3, zero_qubits=1)) & ut.ConstantIntegerAddition(bits=4, constant=-4))
+        ut.Projection(subspace_from=ut.Subspace("####"), subspace_to=ut.Subspace("0###"))
+        @ (ut.Adjoint(prep) & ut.Identity(ut.Subspace("####")))
+        @ (ut.Identity(ut.Subspace("0###")) & ut.ConstantIntegerAddition(bits=4, constant=-4))
         @ ut.IntegerAddition(source_bits=3, target_bits=4)
-        @ (prep & ut.Identity(subspace=ut.Subspace(bits=4)))
-        @ ut.Projection(subspace_from=ut.Subspace(bits=3, zero_qubits=1), subspace_to=ut.Subspace(bits=4))
+        @ (prep & ut.Identity(ut.Subspace("####")))
+        @ ut.Projection(subspace_from=ut.Subspace("0###"), subspace_to=ut.Subspace("####"))
     )
     ut.verify(conv)
 
@@ -34,8 +34,8 @@ def test_2d_gaussian_conv():
     one_dim_conv = ut.Mul(
         ut.Mul(
             ut.Mul(
-                ut.Projection(subspace_from=ut.Subspace(bits=2, zero_qubits=1), subspace_to=ut.Subspace(bits=3)),
-                prep & ut.Identity(bits=3),
+                ut.Projection(subspace_from=ut.Subspace("0##"), subspace_to=ut.Subspace("###")),
+                prep & ut.Identity(ut.Subspace("###")),
                 skip_projection=True,
             ),
             ut.IntegerAddition(source_bits=2, target_bits=3),
@@ -43,11 +43,11 @@ def test_2d_gaussian_conv():
         ),
         ut.Mul(
             ut.Mul(
-                ut.Identity(subspace=ut.Subspace(bits=2)) & ut.ConstantIntegerAddition(bits=3, constant=-2),
-                ut.Adjoint(prep) & ut.Identity(subspace=ut.Subspace(bits=3)),
+                ut.Identity(ut.Subspace("##")) & ut.ConstantIntegerAddition(bits=3, constant=-2),
+                ut.Adjoint(prep) & ut.Identity(ut.Subspace("###")),
                 skip_projection=True,
             ),
-            ut.Projection(subspace_from=ut.Subspace(bits=3), subspace_to=ut.Subspace(bits=2, zero_qubits=1)),
+            ut.Projection(subspace_from=ut.Subspace("###"), subspace_to=ut.Subspace("0##")),
             skip_projection=True,
         ),
         skip_projection=True,

--- a/tests/test_laplace.py
+++ b/tests/test_laplace.py
@@ -161,7 +161,7 @@ def ref_CP_1d(L, DIM):
 def test_laplace(n: int):
     C = ut.Increment(bits=n)
     A = ut.Add(
-        ut.Scale(ut.Identity(subspace=ut.Subspace(bits=n)), -2),
+        ut.Scale(ut.Identity(ut.Subspace("#" * n)), -2),
         ut.Scale(ut.Add(C, ut.Adjoint(C)), 1),
     )
     ut.verify(A)
@@ -174,18 +174,18 @@ def test_preconditioned_laplace_1d():
     C_F = []
 
     for i in range(L, 0, -1):
-        I_l = ut.Projection(ut.Subspace(dim=2**i - 1, bits=i), ut.Subspace(bits=i))
+        I_l = ut.Projection(ut.Subspace.from_dim(2**i - 1, bits=i), ut.Subspace("#" * i))
         N_l = ut.Increment(bits=i) @ I_l
         C_l = 2 ** (i / 2) * (I_l - N_l)
 
-        T_l = ut.ConstantUnitary(np.sqrt(1 / 2) * np.array([[1], [1]])) & ut.Identity(subspace=ut.Subspace(bits=i - 1))
+        T_l = ut.ConstantUnitary(np.sqrt(1 / 2) * np.array([[1], [1]])) & ut.Identity(ut.Subspace("#" * (i - 1)))
         # T_l = ConstantUnitary(
         #     np.sqrt(1 / 2) * np.array([
         #         [1, -np.sqrt(3) / 2],
         #         [0, 1 / 2],
         #         [1, np.sqrt(3) / 2],
         #         [0, 1 / 2],
-        #     ])) & Identity(subspace=Subspace(l - 1))
+        #     ])) & Subspace(l - 1))
 
         if i == L:
             TC = 2 ** (-i / 2) * C_l

--- a/tests/test_pcg.py
+++ b/tests/test_pcg.py
@@ -31,9 +31,8 @@ class LCG(ut.ProxyNode):
                 skip_projection=True,
             )
             controlled = (
-                ut.Identity(ut.Subspace([ut.ID] * self.bits + [ut.ZeroQubit()] * 2 + [ut.ID] * i))
-                | (step & ut.Identity(bits=i))
-            ) & ut.Identity(bits=self.bits - i - 1)
+                ut.Identity(ut.Subspace("#" * i + "00" + "#" * self.bits)) | (step & ut.Identity(ut.Subspace("#" * i)))
+            ) & ut.Identity(ut.Subspace("#" * (self.bits - i - 1)))
             if result is None:
                 result = controlled
             else:

--- a/tests/test_subspace.py
+++ b/tests/test_subspace.py
@@ -4,178 +4,99 @@ import unitaria as ut
 
 
 def test_eq():
-    assert ut.Subspace(bits=0) == ut.Subspace(bits=0)
-    assert ut.Subspace(bits=1) == ut.Subspace(bits=1)
-    assert ut.Subspace(bits=0, zero_qubits=1) == ut.Subspace(bits=0, zero_qubits=1)
-    assert ut.Subspace(bits=1, zero_qubits=0) != ut.Subspace(bits=1, zero_qubits=1)
-    assert ut.Subspace(bits=1) == ut.Subspace([ut.ID])
-    c = ut.ControlledSubspace(ut.Subspace(bits=0), ut.Subspace(bits=0))
-    assert ut.Subspace(bits=1) == ut.Subspace([c])
-    c = ut.ControlledSubspace(ut.Subspace(bits=1), ut.Subspace(bits=0, zero_qubits=1))
-    assert ut.Subspace([c]) == ut.Subspace([c])
-    assert ut.Subspace([c]) != ut.Subspace(bits=1)
-
-
-def test_is_trivial():
-    assert ut.Subspace(bits=0).is_trivial()
-    assert ut.Subspace(bits=0, zero_qubits=1).is_trivial()
-    assert not ut.Subspace(bits=1).is_trivial()
-    assert not ut.Subspace(
-        [ut.ControlledSubspace(ut.Subspace(bits=1), ut.Subspace(bits=0, zero_qubits=1))]
-    ).is_trivial()
-    assert not ut.Subspace(
-        [
-            ut.ID,
-            ut.ControlledSubspace(ut.Subspace(bits=0, zero_qubits=1), ut.Subspace(bits=0, zero_qubits=1)),
-        ],
-        zero_qubits=2,
-    ).is_trivial()
+    assert ut.Subspace() == ut.Subspace()
+    assert ut.Subspace("#") == ut.Subspace("#")
+    assert ut.Subspace("0") == ut.Subspace("0")
+    assert ut.Subspace("#") != ut.Subspace("#0")
+    assert ut.Subspace("#") & ut.Subspace("0") == ut.Subspace("#0")
+    assert ut.Subspace("#") == ut.Subspace([ut.ID])
+    c = ut.Subspace() | ut.Subspace()
+    assert ut.Subspace("#") == c
+    c = ut.Subspace("#") | ut.Subspace("0")
+    assert c == c
+    assert c != ut.Subspace("#")
 
 
 def test_basis():
-    assert ut.Subspace(bits=0, zero_qubits=1).test_basis(0)
-    assert not ut.Subspace(bits=0, zero_qubits=1).test_basis(1)
+    assert ut.Subspace("0").test_basis(0)
+    assert not ut.Subspace("0").test_basis(1)
 
-    np.testing.assert_allclose(ut.Subspace(bits=0).enumerate_basis(), np.array([0]))
-    np.testing.assert_allclose(ut.Subspace(bits=0, zero_qubits=1).enumerate_basis(), np.array([0]))
-    np.testing.assert_allclose(ut.Subspace(bits=1).enumerate_basis(), np.array([0, 1]))
+    np.testing.assert_allclose(ut.Subspace().enumerate_basis(), np.array([0]))
+    np.testing.assert_allclose(ut.Subspace("0").enumerate_basis(), np.array([0]))
+    np.testing.assert_allclose(ut.Subspace("#").enumerate_basis(), np.array([0, 1]))
     np.testing.assert_allclose(
-        ut.Subspace([ut.ControlledSubspace(ut.Subspace(bits=1), ut.Subspace(bits=0, zero_qubits=1))]).enumerate_basis(),
+        ut.Subspace([ut.ControlledSubspace(ut.Subspace("#"), ut.Subspace("0"))]).enumerate_basis(),
         np.array([0, 1, 2]),
     )
     # TODO
     # circuit = Circuit()
     np.testing.assert_allclose(
-        ut.Subspace(
-            [
-                ut.ID,
-                # Controlled(QubitMap(0, 1), QubitMap(0, 1)),
-            ],
-            zero_qubits=1,
-        ).enumerate_basis(),
+        ut.Subspace("0#").enumerate_basis(),
         np.array([0, 1]),
     )
 
 
 def test_total_qubits():
-    assert ut.Subspace(bits=0).total_qubits == 0
-    assert ut.Subspace(bits=0, zero_qubits=1).total_qubits == 1
-    assert ut.Subspace(bits=1).total_qubits == 1
-    assert (
-        ut.Subspace([ut.ControlledSubspace(ut.Subspace(bits=1), ut.Subspace(bits=0, zero_qubits=1))]).total_qubits == 2
-    )
-    assert (
-        ut.Subspace(
-            [
-                ut.ID,
-                ut.ControlledSubspace(ut.Subspace(bits=0, zero_qubits=1), ut.Subspace(bits=0, zero_qubits=1)),
-            ],
-            zero_qubits=2,
-        ).total_qubits
-        == 5
-    )
+    assert ut.Subspace().total_qubits == 0
+    assert ut.Subspace("0").total_qubits == 1
+    assert ut.Subspace("#").total_qubits == 1
+    assert (ut.Subspace("#") | ut.Subspace("0")).total_qubits == 2
+    assert (ut.Subspace("#") & (ut.Subspace("0") | ut.Subspace("0")) & ut.Subspace("00")).total_qubits == 5
+
+
+examples = [
+    ut.Subspace(),
+    ut.Subspace("0#"),
+    (ut.Subspace("#") | ut.Subspace("0")) & ut.Subspace("#"),
+    ((ut.Subspace("#") & (ut.Subspace("0") | ut.Subspace("#"))) | ut.Subspace("00#")) & ut.Subspace("#"),
+]
 
 
 @pytest.mark.parametrize(
     "subspace",
-    [
-        ut.Subspace(bits=0),
-        ut.Subspace(bits=1, zero_qubits=1),
-        ut.Subspace([ut.ID, ut.ControlledSubspace(ut.Subspace(bits=1), ut.Subspace(bits=0, zero_qubits=1))]),
-        ut.Subspace(
-            [
-                ut.ID,
-                ut.ControlledSubspace(
-                    ut.Subspace(
-                        [
-                            ut.ControlledSubspace(ut.Subspace(bits=0, zero_qubits=1), ut.Subspace(bits=1)),
-                            ut.ID,
-                        ]
-                    ),
-                    ut.Subspace(bits=1, zero_qubits=2),
-                ),
-            ]
-        ),
-    ],
+    examples,
 )
 def test_circuit(subspace: ut.Subspace):
     subspace.verify_circuit()
 
 
-@pytest.mark.parametrize(
-    "subspace",
-    [
-        ut.Subspace(bits=0),
-        ut.Subspace(bits=1, zero_qubits=1),
-        ut.Subspace([ut.ID, ut.ControlledSubspace(ut.Subspace(bits=1), ut.Subspace(bits=0, zero_qubits=1))]),
-        ut.Subspace(
-            [
-                ut.ID,
-                ut.ControlledSubspace(
-                    ut.Subspace(
-                        [ut.ControlledSubspace(ut.Subspace(bits=0, zero_qubits=1), ut.Subspace(bits=1)), ut.ID]
-                    ),
-                    ut.Subspace(bits=1, zero_qubits=2),
-                ),
-            ]
-        ),
-    ],
-)
-def test_trailing_zeros(subspace):
-    trailing_zeros = subspace.trailing_zeros()
-    assert len(subspace.tensor_factors) >= trailing_zeros
-    assert trailing_zeros == len(subspace.tensor_factors) or isinstance(
-        subspace.tensor_factors[-(trailing_zeros + 1)], ut.ControlledSubspace
+@pytest.mark.parametrize("subspace", examples)
+def test_initial_zeros(subspace):
+    initial_zeros = subspace.initial_zeros()
+    assert len(subspace.tensor_factors) >= initial_zeros
+    assert initial_zeros == len(subspace.tensor_factors) or isinstance(
+        subspace.tensor_factors[-(initial_zeros + 1)], ut.ControlledSubspace
     )
 
 
 def test_case_zero():
-    assert ut.Subspace(bits=0).case_zero() is None
-    assert ut.Subspace(bits=1, zero_qubits=1).case_zero() == ut.Subspace(bits=0)
-    assert ut.Subspace(
-        [ut.ID, ut.ControlledSubspace(ut.Subspace(bits=1), ut.Subspace(bits=0, zero_qubits=1))]
-    ).case_zero() == ut.Subspace(bits=2)
+    assert ut.Subspace().case_zero() is None
+    assert ut.Subspace("0#").case_zero() == ut.Subspace()
+    assert ((ut.Subspace("#") | ut.Subspace("0")) & ut.Subspace("#")).case_zero() == ut.Subspace("##")
 
-    subspace = ut.Subspace(
-        [
-            ut.ID,
-            ut.ControlledSubspace(
-                ut.Subspace(bits=0, zero_qubits=2),
-                ut.Subspace([ut.ControlledSubspace(ut.Subspace(bits=0, zero_qubits=1), ut.Subspace(bits=1))]),
-            ),
-        ]
-    )
-    case_zero = ut.Subspace(
-        bits=1,
-        zero_qubits=2,
-    )
+    subspace = (ut.Subspace("00") | (ut.Subspace("0") | ut.Subspace("#"))) & ut.Subspace("#")
+    case_zero = ut.Subspace("00#")
     assert subspace.case_zero() == case_zero
 
 
 @pytest.mark.parametrize(
     ("subspace", "expected"),
     [
-        (ut.Subspace(bits=0), "<zero qubit subspace>"),
-        (ut.Subspace(bits=1, zero_qubits=1),
+        (ut.Subspace(), "<zero qubit subspace>"),
+        (ut.Subspace("0#"),
             "  │\n"
             "1 0\n"
             "  │\n"
             "0 #"
         ),
-        (ut.Subspace([ut.ID, ut.ControlledSubspace(ut.Subspace(bits=1), ut.Subspace(bits=0, zero_qubits=1))]),
+        ((ut.Subspace("#") | ut.Subspace("0")) & ut.Subspace("#"),
             "  │\n"
             "2 ?─┬─┐\n"
             "    │ │\n"
             "1   # 0\n"
             "  ╔═╩═╛\n"
             "0 #"),
-        (
-            ut.Subspace(
-                [
-                    ut.ID,
-                    ut.ControlledSubspace(ut.Subspace([ut.ControlledSubspace(ut.Subspace(bits=0, zero_qubits=1), ut.Subspace(bits=1)), ut.ID]), ut.Subspace(bits=1, zero_qubits=2)),
-                ]
-            ),
+        (((ut.Subspace("#") & (ut.Subspace("0") | ut.Subspace("#"))) | ut.Subspace("00#")) & ut.Subspace("#"),
             "  │\n"
             "4 ?─┬─────┐\n"
             "    │     │\n"
@@ -185,8 +106,7 @@ def test_case_zero():
             "      │ │ │\n"
             "1     0 # #\n"
             "  ╔═══╧═╩═╝\n"
-            "0 #"
-        ),
+            "0 #"),
     ],
 )  # fmt: skip
 def test_str(subspace: ut.Subspace, expected: str):

--- a/tests/test_subspace.py
+++ b/tests/test_subspace.py
@@ -9,7 +9,7 @@ def test_eq():
     assert ut.Subspace("0") == ut.Subspace("0")
     assert ut.Subspace("#") != ut.Subspace("#0")
     assert ut.Subspace("#") & ut.Subspace("0") == ut.Subspace("#0")
-    assert ut.Subspace("#") == ut.Subspace([ut.ID])
+    assert ut.Subspace("#") == ut.Subspace([ut.ControlledSubspace(ut.Subspace(), ut.Subspace())])
     c = ut.Subspace() | ut.Subspace()
     assert ut.Subspace("#") == c
     c = ut.Subspace("#") | ut.Subspace("0")


### PR DESCRIPTION
Introduces a new constructor for Subspaces, and changes the codebase to mostly use that constructor and the `&` and `|` operators.

This also changes the order of arguments in the `&` operator. This is equivalent to the problem in #60, but that issue relates to the `Tensor` class.

I tried to keep all tests exactly the same.