### PR TITLE
Implement versioned docs

### DIFF
--- a/.github/workflows/ci_pytest.yml
+++ b/.github/workflows/ci_pytest.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
-          version: "0.11.3"
+          version: "0.11.7"
           enable-cache: true
       - name: Install dependencies
         run: uv sync --dev

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -2,29 +2,39 @@ name: Deploy documentation
 on:
   push:
     branches:
-    - main
+      - main
+    tags:
+      - '*'
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
         with:
-          version: "0.10.9"
+          version: "0.11.7"
           enable-cache: true
       - name: Install dependencies
         run: uv sync --group docs
       - name: Build documentation
         working-directory: ./docs
-        run: uv run make html
+        run: |
+          DOCS_VERSION=git uv run make html
+          CURRENT_COMMIT=$(git rev-parse HEAD)
+          for tag in $(git tag --sort=-v:refname); do
+            git checkout --quiet tags/$tag
+            uv sync --group docs
+            DOCS_VERSION=$tag uv run make html
+          done
+          git checkout --quiet $CURRENT_COMMIT
       - name: Upload GitHub Pages artifact
-        uses: actions/upload-pages-artifact@v4.0.0
+        uses: actions/upload-pages-artifact@v5
         with:
           path: docs/_build/html
   deploy:
@@ -39,4 +49,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4.0.5
+        uses: actions/deploy-pages@v5

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -7,6 +7,7 @@ SPHINXOPTS    ?=
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = .
 BUILDDIR      = _build
+DOCS_VERSION  ?= git
 
 # Put it first so that "make" without argument is like "make help".
 help:
@@ -14,7 +15,5 @@ help:
 
 .PHONY: help Makefile
 
-# Catch-all target: route all unknown targets to Sphinx using the new
-# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
-%: Makefile
-	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+html:
+	@$(SPHINXBUILD) -b html "$(SOURCEDIR)" "$(BUILDDIR)/html/$(DOCS_VERSION)" $(SPHINXOPTS) $(O)

--- a/docs/_templates/versions.html
+++ b/docs/_templates/versions.html
@@ -1,0 +1,22 @@
+<div class="furo-version-switcher" style="padding: 1rem; border-top: 1px solid var(--color-sidebar-item-background--hover);">
+  <label for="version-select" style="display: block; margin-bottom: 0.5rem; font-weight: bold; color: var(--color-foreground-primary);">
+    Version: {{ current_version }}
+  </label>
+  <select id="version-select" style="width: 100%; padding: 0.25rem; border-radius: 4px; border: 1px solid var(--color-sidebar-item-background--hover); background-color: var(--color-background-primary); color: var(--color-foreground-primary);">
+    {% for version in versions %}
+        <option value="{{ version }}" {% if version == current_version %}selected{% endif %}>
+          {{ version }}
+        </option>
+    {% endfor %}
+  </select>
+</div>
+
+<script>
+  document.getElementById('version-select').addEventListener('change', function() {
+    const targetVersion = this.value;
+    const currentVersion = "{{ current_version }}";
+    const currentUrl = window.location.href;
+    const newUrl = currentUrl.replace('/' + currentVersion + '/', '/' + targetVersion + '/');
+    window.location.href = newUrl;
+  });
+</script>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -83,8 +83,8 @@ html_sidebars = {
 }
 
 html_context = {
-  "current_version" : version,
-  "versions" : ["git"] + tags,
+    "current_version": version,
+    "versions": ["git"] + tags,
 }
 
 # -- Options for todo extension ----------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,6 +4,7 @@
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
 import os
+import subprocess
 import sys
 
 sys.path.insert(0, os.path.abspath("../src"))
@@ -15,8 +16,12 @@ project = "unitaria"
 copyright = "2025, Matthias Deiml"
 author = "Matthias Deiml"
 
-version = "0.1"
-release = "0.1"
+version = os.environ.get("DOCS_VERSION", "git")
+release = version
+try:
+    tags = subprocess.check_output(["git", "tag", "--sort=-v:refname"]).decode("utf-8").splitlines()
+except Exception:
+    tags = []
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
@@ -66,6 +71,21 @@ html_static_path = ["_static"]
 html_css_files = [
     "css/imgmath_furo.css",
 ]
+html_sidebars = {
+    "**": [
+        "sidebar/scroll-start.html",
+        "sidebar/brand.html",
+        "sidebar/search.html",
+        "sidebar/navigation.html",
+        "sidebar/scroll-end.html",
+        "versions.html",
+    ]
+}
+
+html_context = {
+  "current_version" : version,
+  "versions" : ["git"] + tags,
+}
 
 # -- Options for todo extension ----------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/extensions/todo.html#configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "uv_build"
 name = "unitaria"
 authors = [
   {name = "Matthias Deiml", email = "matthias.deiml@uni-a.de"},
-  {name = "Oliver Hüttenhofen", email = "oliver.huettenhofer@uni-a.de"},
+  {name = "Oliver Hüttenhofer", email = "oliver.huettenhofer@uni-a.de"},
   {name = "Jakob S. Kottmann", email = "jakob.kottmann@uni-a.de"},
   {name = "Ram Mosco", email = "ram.mosco@uni-a.de"},
   {name = "Daniel Peterseim", email = "daniel.peterseim@uni-a.de"}
@@ -41,11 +41,9 @@ classifiers = [
   "Topic :: Scientific/Engineering :: Quantum Computing",
 ]
 
-[dependency-groups]
+[project.optional-dependencies]
 docs = ["sphinx", "furo"]
 dev = ["pytest"]
-
-[project.optional-dependencies]
 qpic = ["qpic==1.1.*"]
 
 [project.urls]


### PR DESCRIPTION
This branch was meant to switch to sphinx-multiversion, which doesn't work because of https://github.com/sphinx-contrib/multiversion/issues/201.

Because I couldn't find any other package that is still maintained and offers this functionality, I implemented it myself, based on [this blog post](https://www.codingwiththomas.com/blog/my-sphinx-best-practice-for-a-multiversion-documentation-in-different-languages), adjusted to our theme and to automatically query Git tags, with AI help for the HTML and CI files.