### PR TITLE
Update test_gaussian_conv

### DIFF
--- a/tests/test_gaussian_conv.py
+++ b/tests/test_gaussian_conv.py
@@ -4,35 +4,33 @@ import unitaria as ut
 
 
 def test_1d_gaussian_conv():
-    x = np.arange(-3, 4) / 2
-    gaussian = np.exp(-(x**2))
-    prep = ut.ConstantVector(np.append([0], np.sqrt(gaussian)))
-    conv = (
-        (ut.Identity(ut.Subspace.from_dim(16)) & ut.Adjoint(prep))
-        @ (ut.ConstantIntegerAddition(bits=4, constant=-4) & ut.Identity(ut.Subspace.from_dim(8)))
-        @ ut.IntegerAddition(source_bits=3, target_bits=4)
-        @ (ut.Identity(ut.Subspace.from_dim(16)) & prep)
-    )[:8, :8]
+    kernel = np.exp(-((np.arange(-3, 4) / 4) ** 2))
+    padded_kernel = np.append(kernel, 0)
+
+    prep = ut.Identity(ut.Subspace.from_dim(16)) & ut.ConstantVector(np.sqrt(padded_kernel))
+    add = ut.IntegerAddition(source_bits=3, target_bits=4)
+    const_add = ut.ConstantIntegerAddition(bits=4, constant=-3) & ut.Identity(ut.Subspace.from_dim(8))
+    unprep = ut.Adjoint(prep)
+
+    conv = (unprep @ const_add @ add @ prep)[:8, :8]
     ut.verify(conv)
 
     input = np.linspace(0.0, 1.0, 8)
     input /= np.linalg.norm(input)
     result = conv.compute(input)
-    expected = scipy.signal.convolve(input, gaussian, mode="same")
+    expected = scipy.signal.convolve(input, kernel, mode="same")
     assert np.allclose(result, expected)
 
 
 def test_2d_gaussian_conv():
-    x = np.arange(-1, 2)
-    gaussian = np.exp(-(x**2))
-    prep = ut.ConstantVector(np.append([0], np.sqrt(gaussian)))
+    kernel = np.exp(-((np.arange(-1, 2) / 4) ** 2))
+    padded_kernel = np.append(kernel, 0)
 
-    one_dim_conv = (
-        (ut.Identity(ut.Subspace.from_dim(8)) & ut.Adjoint(prep))
-        @ (ut.ConstantIntegerAddition(bits=3, constant=-2) & ut.Identity(ut.Subspace.from_dim(4)))
-        @ ut.IntegerAddition(source_bits=2, target_bits=3)
-        @ (ut.Identity(ut.Subspace.from_dim(8)) & prep)
-    )[:4, :4]
+    prep = ut.Identity(ut.Subspace.from_dim(8)) & ut.ConstantVector(np.sqrt(padded_kernel))
+    add = ut.IntegerAddition(source_bits=2, target_bits=3)
+    const_add = ut.ConstantIntegerAddition(bits=3, constant=-1) & ut.Identity(ut.Subspace.from_dim(4))
+    unprep = ut.Adjoint(prep)
+    one_dim_conv = (unprep @ const_add @ add @ prep)[:4, :4]
 
     two_dim_conv = one_dim_conv & one_dim_conv
     print(f"qubits: {two_dim_conv.circuit().n_qubits}")
@@ -41,5 +39,5 @@ def test_2d_gaussian_conv():
     input = np.outer(np.linspace(0.0, 1.0, 4), np.linspace(0.0, 1.0, 4))
     input /= np.linalg.norm(input)
     result = two_dim_conv.compute(input.flatten()).reshape((4, 4))
-    expected = scipy.signal.convolve(input, np.outer(gaussian, gaussian), mode="same")
+    expected = scipy.signal.convolve(input, np.outer(kernel, kernel), mode="same")
     assert np.allclose(result, expected)


### PR DESCRIPTION
Changes the Gaussian convolution test to align more closely with the code example in the paper. There should be no functional change, but I think it might be useful to have them match, e.g. if something breaks.