### PR TITLE
Fix setting n_qubits when initializing `Circuit`

### DIFF
--- a/src/unitaria/circuit.py
+++ b/src/unitaria/circuit.py
@@ -35,6 +35,7 @@ class Circuit:
     def __init__(self, tq_circuit: tq.QCircuit | None = None):
         if tq_circuit is not None:
             self._tq_circuit = tq_circuit
+            self.n_qubits = tq_circuit.n_qubits
         else:
             self._tq_circuit = tq.QCircuit()
 

--- a/tests/nodes/test_block_encoding.py
+++ b/tests/nodes/test_block_encoding.py
@@ -17,3 +17,8 @@ def create_block_encoding():
 def test_block_encoding_x_gate_on_first_qubit():
     block_encoding = create_block_encoding()
     ut.verify(block_encoding)
+
+
+def test_nonempty_circuit():
+    A = ut.BlockEncoding(ut.Circuit(tq.gates.X(target=0)), ut.Subspace("#"), ut.Subspace("#"), normalization=1)
+    ut.verify(A)


### PR DESCRIPTION
Currently, the `Circuit` class doesn't set n_qubits when constructing it from a Tequila Circuit. This fixes that and adds a test that would have caught it.