### PR TITLE
Allow for more than minimum amount of qubits

### DIFF
--- a/src/unitaria/nodes/basic/modify_control.py
+++ b/src/unitaria/nodes/basic/modify_control.py
@@ -70,7 +70,7 @@ class ModifyControl(Node):
         if self.swap_control_state:
             circuit += tq.gates.X(control_qubit_post)
 
-        original_circuit = self.A.circuit(target, clean_ancillae, borrowed_ancillae)
+        original_circuit = self.A.circuit(target[: subspace.total_qubits], clean_ancillae, borrowed_ancillae)
         qubit_map = {t: t for t in range(original_circuit.n_qubits)}
         qubit_map[control_qubit_pre] = control_qubit_post
         circuit += original_circuit.map_qubits(qubit_map)

--- a/src/unitaria/nodes/basic/tensor.py
+++ b/src/unitaria/nodes/basic/tensor.py
@@ -81,17 +81,17 @@ class Tensor(Node):
     def _circuit(
         self, target: Sequence[int], clean_ancillae: Sequence[int], borrowed_ancillae: Sequence[int]
     ) -> Circuit:
-        # TODO: Optionally optimize for qubit count instead of depth?
+        # TODO: Optionally try to run A and B in parallel by allocating ancillas differently?
         circuit = Circuit()
         circuit += self.B.circuit(
             target[: self.B.target_qubit_count()],
-            clean_ancillae[: self.B.clean_ancilla_count()],
-            borrowed_ancillae[: self.B.borrowed_ancilla_count()],
+            clean_ancillae,
+            borrowed_ancillae,
         )
         circuit += self.A.circuit(
             target[self.B.target_qubit_count() :],
-            clean_ancillae[self.B.clean_ancilla_count() :],
-            borrowed_ancillae[self.B.borrowed_ancilla_count() :],
+            clean_ancillae,
+            borrowed_ancillae,
         )
         return circuit
 

--- a/src/unitaria/nodes/basic/tensor.py
+++ b/src/unitaria/nodes/basic/tensor.py
@@ -112,10 +112,10 @@ class Tensor(Node):
         return self.A.is_guaranteed_unitary() and self.B.is_guaranteed_unitary()
 
     def clean_ancilla_count(self) -> int:
-        return self.A.clean_ancilla_count() + self.B.clean_ancilla_count()
+        return max(self.A.clean_ancilla_count(), self.B.clean_ancilla_count())
 
     def borrowed_ancilla_count(self) -> int:
-        return self.A.borrowed_ancilla_count() + self.B.borrowed_ancilla_count()
+        return max(self.A.borrowed_ancilla_count(), self.B.borrowed_ancilla_count())
 
 
 Node.__and__ = lambda A, B: Tensor(A, B)

--- a/src/unitaria/nodes/basic/unsafe_multiplication.py
+++ b/src/unitaria/nodes/basic/unsafe_multiplication.py
@@ -51,8 +51,8 @@ class UnsafeMul(Node):
         self, target: Sequence[int], clean_ancillae: Sequence[int], borrowed_ancillae: Sequence[int]
     ) -> Circuit:
         circuit = Circuit()
-        circuit += self.B.circuit(target, clean_ancillae, borrowed_ancillae)
-        circuit += self.A.circuit(target, clean_ancillae, borrowed_ancillae)
+        circuit += self.B.circuit(target[: self.B.subspace_in.total_qubits], clean_ancillae, borrowed_ancillae)
+        circuit += self.A.circuit(target[: self.A.subspace_in.total_qubits], clean_ancillae, borrowed_ancillae)
         return circuit
 
     def _subspace_in(self) -> Subspace:

--- a/src/unitaria/nodes/node.py
+++ b/src/unitaria/nodes/node.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Sequence
+from functools import lru_cache
 
 import numpy as np
 from rich.tree import Tree
@@ -205,35 +206,29 @@ class Node(ABC):
             assert clean_ancillae is None
             assert borrowed_ancillae is None
             __tracebackhide__ = True
-            target = range(self.target_qubit_count())
-            clean_ancillae = range(self.target_qubit_count(), self.target_qubit_count() + self.clean_ancilla_count())
-            borrowed_ancillae = range(
-                self.target_qubit_count() + self.clean_ancilla_count(),
-                self.target_qubit_count() + self.clean_ancilla_count() + self.borrowed_ancilla_count(),
+            circuit = self._cached_circuit(self.clean_ancilla_count(), self.borrowed_ancilla_count())
+            circuit.n_qubits = max(
+                self.target_qubit_count() + self.clean_ancilla_count() + self.borrowed_ancilla_count(), 1
             )
+            return circuit
         else:
-            assert len(target) >= self.target_qubit_count()
+            assert len(target) == self.target_qubit_count()
             assert len(clean_ancillae) >= self.clean_ancilla_count()
             assert len(borrowed_ancillae) >= self.borrowed_ancilla_count()
             total_num = len(target) + len(clean_ancillae) + len(borrowed_ancillae)
             # Make sure that all passed qubit indices are unique
             assert len(set(target) | set(clean_ancillae) | set(borrowed_ancillae)) == total_num
 
-        circuit = self._cached_circuit.map_qubits(
-            {i: target[i] for i in range(self.target_qubit_count())}
-            | {self.target_qubit_count() + i: clean_ancillae[i] for i in range(self.clean_ancilla_count())}
-            | {
-                self.target_qubit_count() + self.clean_ancilla_count() + i: borrowed_ancillae[i]
-                for i in range(self.borrowed_ancilla_count())
-            }
+        circuit = self._cached_circuit(len(clean_ancillae), len(borrowed_ancillae)).map_qubits(
+            {i: bit for i, bit in enumerate(list(target) + list(clean_ancillae) + list(borrowed_ancillae))}
         )
         circuit.n_qubits = (
             max(max(target, default=0), max(clean_ancillae, default=0), max(borrowed_ancillae, default=0)) + 1
         )
         return circuit
 
-    @cached_property
-    def _cached_circuit(self):
+    @lru_cache
+    def _cached_circuit(self, clean_ancilla_count: int, borrowed_ancilla_count: int):
         """
         Calls _circuit with target, clean_ancillae and borrowed_ancillae
         being the qubits 0, 1, ... so that the result can be cached.
@@ -241,10 +236,10 @@ class Node(ABC):
         """
         __tracebackhide__ = True
         target = range(self.target_qubit_count())
-        clean_ancillae = range(self.target_qubit_count(), self.target_qubit_count() + self.clean_ancilla_count())
+        clean_ancillae = range(self.target_qubit_count(), self.target_qubit_count() + clean_ancilla_count)
         borrowed_ancillae = range(
-            self.target_qubit_count() + self.clean_ancilla_count(),
-            self.target_qubit_count() + self.clean_ancilla_count() + self.borrowed_ancilla_count(),
+            self.target_qubit_count() + clean_ancilla_count,
+            self.target_qubit_count() + clean_ancilla_count + borrowed_ancilla_count,
         )
         return self._circuit(target, clean_ancillae, borrowed_ancillae)
 
@@ -266,18 +261,19 @@ class Node(ABC):
     @abstractmethod
     def clean_ancilla_count(self) -> int:
         """
-        Returns the number of borrowed ancillae used by the circuit of this node,
-        i.e. qubits that must be in state ``|0>`` at the beginning of the circuit and
-        will be returned to this state by the end of the circuit.
+        Returns the minimum number of clean ancillae required for the circuit
+        of this node, i.e. qubits that must be in state ``|0>`` at the beginning
+        of the circuit and will be returned to this state by the end of the
+        circuit.
         """
         raise NotImplementedError
 
     @abstractmethod
     def borrowed_ancilla_count(self) -> int:
         """
-        Returns the number of borrowed ancillae used by the circuit of this node,
-        i.e. qubits that can be in any state and will be returned to this state by
-        the end of the circuit.
+        Returns the minimum number of borrowed ancillae required for the circuit
+        of this node, i.e. qubits that can be in any state and will be returned
+        to this state by the end of the circuit.
         """
         raise NotImplementedError
 


### PR DESCRIPTION
Allows to pass more than the ancillas given by `Node.clean_ancilla_count` and `Node.borrowed_ancilla_count`. Previsouly these bits were not passed to `_circuit`. This changes the implementation so that for each combination of clean and borrowed ancillae there is a cached circuit.

I don't think this is a good design yet, as it is not communicated beforehand if these ancillas are actually used, but it is future-safe enough IMO