### PR TITLE
Implement phase estimation for `Simulator`

### DIFF
--- a/src/unitaria/circuits/arithmetic.py
+++ b/src/unitaria/circuits/arithmetic.py
@@ -1,7 +1,8 @@
-import copy
 from typing import Sequence
 
 import tequila as tq
+
+from unitaria.circuits.logic import multi_controlled_not_v_chain_borrowed
 
 
 def addition_circuit(source: Sequence[int], target: Sequence[int]) -> tq.QCircuit:
@@ -87,7 +88,7 @@ def increment_circuit_single_ancilla(target: Sequence[int], ancilla: int, second
                 target=[ancilla] + list(target[split:]), ancillae=list(target[:split]) + [second_ancilla]
             )
         else:
-            upper_inc += multi_controlled_not(
+            upper_inc += multi_controlled_not_v_chain_borrowed(
                 target=target[-1], controls=list(target[split:-1]) + [ancilla], ancillae=target[:split]
             )
             upper_inc += increment_circuit_n_ancillae(
@@ -96,18 +97,18 @@ def increment_circuit_single_ancilla(target: Sequence[int], ancilla: int, second
     else:
         upper_inc += increment_circuit_n_ancillae(target=[ancilla] + list(target[split:]), ancillae=target[:split])
 
-    U += copy.deepcopy(upper_inc)
+    U += upper_inc
     U += tq.gates.X(target=ancilla)
 
     for i in range(split, n):
         U += tq.gates.CNOT(control=ancilla, target=target[i])
 
-    U += multi_controlled_not(target=ancilla, controls=target[:split], ancillae=target[split:])
+    U += multi_controlled_not_v_chain_borrowed(target=ancilla, controls=target[:split], ancillae=target[split:])
 
-    U += copy.deepcopy(upper_inc)
+    U += upper_inc
     U += tq.gates.X(target=ancilla)
 
-    U += multi_controlled_not(target=ancilla, controls=target[:split], ancillae=target[split:])
+    U += multi_controlled_not_v_chain_borrowed(target=ancilla, controls=target[:split], ancillae=target[split:])
 
     for i in range(split, n):
         U += tq.gates.CNOT(control=ancilla, target=target[i])
@@ -154,48 +155,6 @@ def increment_circuit_n_ancillae(target: Sequence[int], ancillae: Sequence[int])
         U += tq.gates.X(target=ancillae[i])
 
     U += addition_circuit(target=target, source=ancillae).dagger()
-
-    return U
-
-
-def multi_controlled_not(
-    target: int, controls: Sequence[int], ancillae: Sequence[int], uncompute: bool = True
-) -> tq.QCircuit:
-    """
-    Implements a multi-controlled NOT gate using Toffoli gates.
-
-    :param target: Index of the target qubit.
-    :param controls: Indices of the control qubits.
-    :param ancillae: Indices of the ancilla qubits.
-    Must contain at least len(controls) - 2 qubits. Ancillae can be in any state,
-    and will be returned to that state by the end of the circuit, except if uncompute is set to False.
-    :param uncompute: Whether to uncompute the ancillae.
-    Can be used an optimization if the circuit is used twice.
-    :return: A circuit implementing the multi-controlled NOT gate.
-    """
-    assert len(ancillae) >= len(controls) - 2
-    assert set(ancillae).isdisjoint(controls)
-    assert target not in set(controls) | set(ancillae)
-
-    if len(controls) <= 2:
-        return tq.gates.X(target=target, control=controls)
-
-    staircase = tq.QCircuit()
-    for i in range(2, len(controls) - 1):
-        staircase += tq.gates.Toffoli(first=controls[i], second=ancillae[i - 2], target=ancillae[i - 1])
-
-    U = tq.QCircuit()
-
-    U += tq.gates.Toffoli(first=controls[-1], second=ancillae[len(controls) - 3], target=target)
-    U += staircase.dagger()
-    U += tq.gates.Toffoli(first=controls[0], second=controls[1], target=ancillae[0])
-    U += copy.deepcopy(staircase)
-    U += tq.gates.Toffoli(first=controls[-1], second=ancillae[len(controls) - 3], target=target)
-
-    if uncompute:
-        U += staircase.dagger()
-        U += tq.gates.Toffoli(first=controls[0], second=controls[1], target=ancillae[0])
-        U += staircase
 
     return U
 

--- a/src/unitaria/circuits/logic.py
+++ b/src/unitaria/circuits/logic.py
@@ -1,0 +1,114 @@
+from typing import Sequence
+
+import tequila as tq
+
+
+def multi_controlled_not(
+    target: int,
+    controls: Sequence[int],
+    clean_ancillae: Sequence[int] = [],
+    borrowed_ancillae: Sequence[int] = [],
+    uncompute: bool = True,
+) -> tq.QCircuit:
+    """
+    Implements a multi-controlled NOT gate using Toffoli gates.
+
+    Will select the best variant depending on the ancillae available, see `multi_controlled_not_v_chain`, `multi_controlled_not_v_chain_borrowed`.
+
+    :param target: Index of the target qubit.
+    :param controls: Indices of the control qubits.
+    :param clean_ancillae: Indices of the clean ancilla qubits. Clean ancillae
+    should start in the 0 state, and will be returned to that state by the end
+    of the circuit, except if uncompute is set to False.
+    :param borrowed_ancillae: Indices of the borrowed ancilla qubits. Clean ancillae
+    may start in any state, and will be returned to that state by the end of the
+    circuit, except if uncompute is set to False.
+    :param uncompute: Whether to uncompute the ancillae.
+    Can be used an optimization if the circuit is used twice.
+    :return: A circuit implementing the multi-controlled NOT gate.
+    """
+    if len(clean_ancillae) > len(controls) - 2:
+        return multi_controlled_not_v_chain(target, controls, clean_ancillae, uncompute)
+    if len(clean_ancillae) + len(borrowed_ancillae) > len(controls) - 2:
+        return multi_controlled_not_v_chain(target, controls, clean_ancillae + borrowed_ancillae, uncompute)
+    return tq.gates.X(target=target, control=controls)
+
+
+def multi_controlled_not_v_chain(
+    target: int, controls: Sequence[int], ancillae: Sequence[int], uncompute: bool = True
+) -> tq.QCircuit:
+    """
+    Implements a multi-controlled NOT gate using Toffoli gates.
+
+    :param target: Index of the target qubit.
+    :param controls: Indices of the control qubits.
+    :param ancillae: Indices of the ancilla qubits.
+    Must contain at least len(controls) - 2 qubits. Ancillae should start in the 0 state,
+    and will be returned to that state by the end of the circuit, except if uncompute is set to False.
+    :param uncompute: Whether to uncompute the ancillae.
+    Can be used an optimization if the circuit is used twice.
+    :return: A circuit implementing the multi-controlled NOT gate.
+    """
+    assert len(ancillae) >= len(controls) - 2
+    assert set(ancillae).isdisjoint(controls)
+    assert target not in set(controls) | set(ancillae)
+    if len(controls) <= 2:
+        return tq.gates.X(target=target, control=controls)
+
+    staircase = tq.QCircuit()
+    for i in range(2, len(controls) - 1):
+        staircase += tq.gates.Toffoli(first=controls[i], second=ancillae[i - 2], target=ancillae[i - 1])
+
+    U = tq.QCircuit()
+
+    U += tq.gates.Toffoli(first=controls[0], second=controls[1], target=ancillae[0])
+    U += staircase
+    U += tq.gates.Toffoli(first=controls[-1], second=ancillae[len(controls) - 3], target=target)
+
+    if uncompute:
+        U += staircase.dagger()
+        U += tq.gates.Toffoli(first=controls[0], second=controls[1], target=ancillae[0])
+
+    return U
+
+
+def multi_controlled_not_v_chain_borrowed(
+    target: int, controls: Sequence[int], ancillae: Sequence[int], uncompute: bool = True
+) -> tq.QCircuit:
+    """
+    Implements a multi-controlled NOT gate using Toffoli gates.
+
+    :param target: Index of the target qubit.
+    :param controls: Indices of the control qubits.
+    :param ancillae: Indices of the ancilla qubits.
+    Must contain at least len(controls) - 2 qubits. Ancillae can be in any state,
+    and will be returned to that state by the end of the circuit, except if uncompute is set to False.
+    :param uncompute: Whether to uncompute the ancillae.
+    Can be used an optimization if the circuit is used twice.
+    :return: A circuit implementing the multi-controlled NOT gate.
+    """
+    assert len(ancillae) >= len(controls) - 2
+    assert set(ancillae).isdisjoint(controls)
+    assert target not in set(controls) | set(ancillae)
+
+    if len(controls) <= 2:
+        return tq.gates.X(target=target, control=controls)
+
+    staircase = tq.QCircuit()
+    for i in range(2, len(controls) - 1):
+        staircase += tq.gates.Toffoli(first=controls[i], second=ancillae[i - 2], target=ancillae[i - 1])
+
+    U = tq.QCircuit()
+
+    U += tq.gates.Toffoli(first=controls[-1], second=ancillae[len(controls) - 3], target=target)
+    U += staircase.dagger()
+    U += tq.gates.Toffoli(first=controls[0], second=controls[1], target=ancillae[0])
+    U += staircase
+    U += tq.gates.Toffoli(first=controls[-1], second=ancillae[len(controls) - 3], target=target)
+
+    if uncompute:
+        U += staircase.dagger()
+        U += tq.gates.Toffoli(first=controls[0], second=controls[1], target=ancillae[0])
+        U += staircase
+
+    return U

--- a/src/unitaria/circuits/logic.py
+++ b/src/unitaria/circuits/logic.py
@@ -27,10 +27,10 @@ def multi_controlled_not(
     Can be used an optimization if the circuit is used twice.
     :return: A circuit implementing the multi-controlled NOT gate.
     """
-    if len(clean_ancillae) > len(controls) - 2:
+    if len(clean_ancillae) >= len(controls) - 2:
         return multi_controlled_not_v_chain(target, controls, clean_ancillae, uncompute)
-    if len(clean_ancillae) + len(borrowed_ancillae) > len(controls) - 2:
-        return multi_controlled_not_v_chain(target, controls, clean_ancillae + borrowed_ancillae, uncompute)
+    if len(clean_ancillae) + len(borrowed_ancillae) >= len(controls) - 2:
+        return multi_controlled_not_v_chain_borrowed(target, controls, clean_ancillae + borrowed_ancillae, uncompute)
     return tq.gates.X(target=target, control=controls)
 
 

--- a/src/unitaria/estimator/backend_estimator.py
+++ b/src/unitaria/estimator/backend_estimator.py
@@ -12,11 +12,29 @@ class BackendEstimator(Estimator):
     """
     Estimator based on a simulated or hardware backend.
 
-    See :external:py:func:`~tequila.simulators.simulator_api.simulate`.
+
+    :param default_precision:
+        Default for the ``precision`` parameter in
+        `~BackendEstiator.estimate_norm`.
+    :param default_failure_probability:
+        Default for the ``failure_probability`` parameter in
+        `~BackendEstimator.estimate_norm`.
+    :param qubits:
+        Determines how many ancillae are passed to `Node.circuit`. Specifically,
+        the total qubits passed to that function will be the maximum of
+        ``qubits`` or the qubits required to encode the node. If you want to
+        run circuits for a specific device, set ``qubits`` to the number of
+        qubits in that device.
+    :param backend_kwargs:
+        Parameters of the backend.
+        See :external:py:func:`~tequila.simulators.simulator_api.simulate`.
     """
 
-    def __init__(self, default_precision: float, default_failure_probability: float = 0.01, **backend_kwargs):
+    def __init__(
+        self, default_precision: float, default_failure_probability: float = 0.01, qubits: int = 0, **backend_kwargs
+    ):
         super().__init__(default_precision, default_failure_probability)
+        self.qubits = qubits
         self.backend_kwargs = backend_kwargs
 
     def estimate_norm(
@@ -34,9 +52,16 @@ class BackendEstimator(Estimator):
 
         samples = sample_bound(normalized_precision, failure_probability)
 
-        circuit = node.circuit()
+        target_qubits = node.subspace_out.total_qubits
+        ancilla_count = max(
+            self.qubits - target_qubits - node.borrowed_ancilla_count(),
+            node.clean_ancilla_count(),
+        )
+        circuit = node._cached_circuit(ancilla_count, node.borrowed_ancilla_count(), False)
+        print(circuit)
 
-        result = tq.simulate(circuit._padded(), samples=samples, **self.backend_kwargs)
+        # tq.simulate may also run circuits on a hardware backend
+        result = tq.simulate(circuit._tq_circuit, samples=samples, **self.backend_kwargs)
         measurement = 0
         successful_samples = 0
         max_result = 2**node.subspace_out.total_qubits - 1

--- a/src/unitaria/estimator/simulator.py
+++ b/src/unitaria/estimator/simulator.py
@@ -21,12 +21,12 @@ class Simulator(Estimator):
         `~Simulator.estimate_norm`.
     :param count_gates:
         Wether to count the number of gates. May be much slower.
-    :param min_qubits:
+    :param qubits:
         Determines how many ancillae are passed to `Node.circuit`.
         Specifically, the total qubits passed to that function will
-        be the maximum of ``min_qubits`` or the qubits required to
+        be the maximum of ``qubits`` or the qubits required to
         encode the node.
-        If you want to estimate gates for a specific device, set ``min_qubits``
+        If you want to estimate gates for a specific device, set ``qubits``
         to the number of qubits in that device.
         This parameter is ignored if ``count_gates`` is not set.
     """
@@ -38,7 +38,7 @@ class Simulator(Estimator):
         default_failure_probability: float | None = None,
         seed: np.random.SeedSequence | None = None,
         count_gates: bool = False,
-        min_qubits: int = 20,
+        qubits: int = 100,
     ):
         if scheme == "exact":
             if default_precision is not None or default_failure_probability is not None:
@@ -59,7 +59,7 @@ class Simulator(Estimator):
         self.seed = seed
         self.rng = np.random.default_rng(seed)
         self.count_gates = count_gates
-        self.min_qubits = min_qubits
+        self.qubits = qubits
         self.gate_count = {}
 
     def estimate_norm(
@@ -97,7 +97,7 @@ class Simulator(Estimator):
             if self.count_gates:
                 target_qubits = node.subspace_out.total_qubits
                 ancilla_count = max(
-                    self.min_qubits - target_qubits - node.borrowed_ancilla_count(),
+                    self.qubits - target_qubits - node.borrowed_ancilla_count(),
                     node.clean_ancilla_count(),
                 )
                 circuit = node._cached_circuit(ancilla_count, node.borrowed_ancilla_count(), False)

--- a/src/unitaria/estimator/simulator.py
+++ b/src/unitaria/estimator/simulator.py
@@ -154,5 +154,20 @@ class Simulator(Estimator):
                     if len(gate.control) == 2:
                         name = "ccx"
                 self.gate_count[name] = self.gate_count.get(name, 0) + samples
+            self.gate_count["t-depth"] = self.gate_count.get("t-depth", 0) + samples * t_depth(compiled)
 
         return result * normalization
+
+def t_depth(circuit: tq.QCircuit) -> int:
+    table = {i: 0 for i in circuit.qubits}
+
+    for gate in circuit.gates:
+        if gate.name.lower() == "phase" and gate.parameter < 3 * np.pi / 8:
+            # gate is T
+            table[gate.qubits[0]] += 1
+        elif len(gate.qubits) > 1:
+            t = max([table[i] for i in gate.qubits])
+            for i in gate.qubits:
+                table[i] = t
+
+    return max(table.values())

--- a/src/unitaria/estimator/simulator.py
+++ b/src/unitaria/estimator/simulator.py
@@ -21,6 +21,14 @@ class Simulator(Estimator):
         `~Simulator.estimate_norm`.
     :param count_gates:
         Wether to count the number of gates. May be much slower.
+    :param min_qubits:
+        Determines how many ancillae are passed to `Node.circuit`.
+        Specifically, the total qubits passed to that function will
+        be the maximum of ``min_qubits`` or the qubits required to
+        encode the node.
+        If you want to estimate gates for a specific device, set ``min_qubits``
+        to the number of qubits in that device.
+        This parameter is ignored if ``count_gates`` is not set.
     """
 
     def __init__(
@@ -30,6 +38,7 @@ class Simulator(Estimator):
         default_failure_probability: float | None = None,
         seed: np.random.SeedSequence | None = None,
         count_gates: bool = False,
+        min_qubits: int = 20,
     ):
         if scheme == "exact":
             if default_precision is not None or default_failure_probability is not None:
@@ -50,6 +59,7 @@ class Simulator(Estimator):
         self.seed = seed
         self.rng = np.random.default_rng(seed)
         self.count_gates = count_gates
+        self.min_qubits = min_qubits
         self.gate_count = {}
 
     def estimate_norm(
@@ -85,7 +95,12 @@ class Simulator(Estimator):
             measurement = self.rng.binomial(samples, information_efficiency**2)
 
             if self.count_gates:
-                circuit = node.circuit()
+                target_qubits = node.subspace_out.total_qubits
+                ancilla_count = max(
+                    self.min_qubits - target_qubits - node.borrowed_ancilla_count(),
+                    node.clean_ancilla_count(),
+                )
+                circuit = node._cached_circuit(ancilla_count, node.borrowed_ancilla_count(), False)
                 # This is actually slightly cheating, since this way the error
                 # of the circuit and sampling might add up to be larger than
                 # precision, but since we only use it to count the gates, the
@@ -103,8 +118,10 @@ class Simulator(Estimator):
                         else:
                             name = "s"
                     if name == "x":
-                        if len(gate.control) > 0:
+                        if len(gate.control) == 1:
                             name = "cx"
+                        if len(gate.control) == 2:
+                            name = "ccx"
                     self.gate_count[name] = self.gate_count.get(name, 0) + samples
 
             return np.sqrt(measurement / samples) * normalization

--- a/src/unitaria/estimator/simulator.py
+++ b/src/unitaria/estimator/simulator.py
@@ -46,8 +46,8 @@ class Simulator(Estimator):
             default_precision = 0
             default_failure_probability = 0
         else:
-            if scheme not in ["monte-carlo"]:
-                raise ValueError('Supported schemes are "exact" and "monte-carlo"')
+            if scheme not in ["monte-carlo", "phase-estimation"]:
+                raise ValueError('Supported schemes are "exact", "monte-carlo" and "phase-estimation"')
             if default_precision is None:
                 raise ValueError('Simulator with scheme != "exact" requires `default_precision` argument')
             if default_failure_probability is None:
@@ -78,8 +78,8 @@ class Simulator(Estimator):
                 raise ValueError('"exact" simulator does not support `precision` or `failure_probability` arguments')
             return node.compute_norm()
 
-        if self.scheme not in ["monte-carlo"]:
-            raise ValueError('Supported schemes are "exact" and "monte-carlo"')
+        if self.scheme not in ["monte-carlo", "phase-estimation"]:
+            raise ValueError('Supported schemes are "exact", "monte-carlo" and "phase-estimation"')
         if precision <= 0:
             raise ValueError('Simulator with scheme != "exact" requires precision > 0')
         if not 0 < failure_probability < 1:
@@ -89,39 +89,70 @@ class Simulator(Estimator):
         normalization = node.normalization
         information_efficiency = norm / normalization
         normalized_precision = precision / normalization
+        samples = None
+        result = None
 
         if self.scheme == "monte-carlo":
             samples = sample_bound(normalized_precision, failure_probability)
             measurement = self.rng.binomial(samples, information_efficiency**2)
+            result = np.sqrt(measurement / samples)
+        elif self.scheme == "phase-estimation":
+            # Following https://arxiv.org/abs/quant-ph/0005055
+            p0 = 8.0 / np.pi**2
 
-            if self.count_gates:
-                target_qubits = node.subspace_out.total_qubits
-                ancilla_count = max(
-                    self.qubits - target_qubits - node.borrowed_ancilla_count(),
-                    node.clean_ancilla_count(),
-                )
-                circuit = node._cached_circuit(ancilla_count, node.borrowed_ancilla_count(), False)
-                # This is actually slightly cheating, since this way the error
-                # of the circuit and sampling might add up to be larger than
-                # precision, but since we only use it to count the gates, the
-                # difference should only be logarithmic.
-                compiler = tq.CircuitCompiler.error_correctable_gate_set(normalized_precision)
-                compiled = compiler.compile_circuit(circuit._tq_circuit)
+            # Find steps such that pi/steps + pi^2/steps^2 <= normalized_precision
+            steps = int(
+                np.ceil((np.pi + np.sqrt(np.pi**2 + 4 * normalized_precision * np.pi**2)) / (2 * normalized_precision))
+            )
 
-                for gate in compiled.gates:
-                    name = gate.name.lower()
-                    if name == "globalphase":
-                        continue
-                    if name == "phase":
-                        if gate.parameter < 3 * np.pi / 8:
-                            name = "t"
-                        else:
-                            name = "s"
-                    if name == "x":
-                        if len(gate.control) == 1:
-                            name = "cx"
-                        if len(gate.control) == 2:
-                            name = "ccx"
-                    self.gate_count[name] = self.gate_count.get(name, 0) + samples
+            # Compute number of tries using Chernoff bound
+            gap = 2 * p0 - 1
+            tries = (
+                1
+                if failure_probability >= 1.0 - p0
+                else max(1, int(np.ceil(2 * np.log(1.0 / failure_probability) / gap**2)))
+            )
 
-            return np.sqrt(measurement / samples) * normalization
+            theta = np.arcsin(np.sqrt(information_efficiency))
+
+            # Distances
+            d = theta / np.pi - np.arange(steps) / steps
+            probs = (np.sinc(steps * d) / np.sinc(d)) ** 2
+            probs /= probs.sum()
+
+            measured = self.rng.choice(steps, p=probs, size=tries)
+
+            samples = tries * steps
+            result = float(np.sin(np.pi * np.median(measured) / steps) ** 2)
+
+        if self.count_gates:
+            target_qubits = node.subspace_out.total_qubits
+            ancilla_count = max(
+                self.qubits - target_qubits - node.borrowed_ancilla_count(),
+                node.clean_ancilla_count(),
+            )
+            circuit = node._cached_circuit(ancilla_count, node.borrowed_ancilla_count(), False)
+            # This is actually slightly cheating, since this way the error
+            # of the circuit and sampling might add up to be larger than
+            # precision, but since we only use it to count the gates, the
+            # difference should only be logarithmic.
+            compiler = tq.CircuitCompiler.error_correctable_gate_set(normalized_precision)
+            compiled = compiler.compile_circuit(circuit._tq_circuit)
+
+            for gate in compiled.gates:
+                name = gate.name.lower()
+                if name == "globalphase":
+                    continue
+                if name == "phase":
+                    if gate.parameter < 3 * np.pi / 8:
+                        name = "t"
+                    else:
+                        name = "s"
+                if name == "x":
+                    if len(gate.control) == 1:
+                        name = "cx"
+                    if len(gate.control) == 2:
+                        name = "ccx"
+                self.gate_count[name] = self.gate_count.get(name, 0) + samples
+
+        return result * normalization

--- a/src/unitaria/estimator/simulator.py
+++ b/src/unitaria/estimator/simulator.py
@@ -58,7 +58,7 @@ class Simulator(Estimator):
             seed = np.random.SeedSequence()
         self.seed = seed
         self.rng = np.random.default_rng(seed)
-        self.count_gates = count_gates
+        self.should_count_gates = count_gates
         self.qubits = qubits
         self.gate_count = {}
 
@@ -125,38 +125,101 @@ class Simulator(Estimator):
             samples = tries * steps
             result = float(np.sin(np.pi * np.median(measured) / steps) ** 2)
 
-        if self.count_gates:
-            target_qubits = node.subspace_out.total_qubits
-            ancilla_count = max(
-                self.qubits - target_qubits - node.borrowed_ancilla_count(),
-                node.clean_ancilla_count(),
-            )
-            circuit = node._cached_circuit(ancilla_count, node.borrowed_ancilla_count(), False)
-            # This is actually slightly cheating, since this way the error
-            # of the circuit and sampling might add up to be larger than
-            # precision, but since we only use it to count the gates, the
-            # difference should only be logarithmic.
-            compiler = tq.CircuitCompiler.error_correctable_gate_set(normalized_precision)
-            compiled = compiler.compile_circuit(circuit._tq_circuit)
-
-            for gate in compiled.gates:
-                name = gate.name.lower()
-                if name == "globalphase":
-                    continue
-                if name == "phase":
-                    if gate.parameter < 3 * np.pi / 8:
-                        name = "t"
-                    else:
-                        name = "s"
-                if name == "x":
-                    if len(gate.control) == 1:
-                        name = "cx"
-                    if len(gate.control) == 2:
-                        name = "ccx"
-                self.gate_count[name] = self.gate_count.get(name, 0) + samples
-            self.gate_count["t-depth"] = self.gate_count.get("t-depth", 0) + samples * t_depth(compiled)
+        if self.should_count_gates:
+            self.count_gates(node, samples=samples)
 
         return result * normalization
+
+    def count_gates(
+        self, node: Node, precision: float | None = None, failure_probability: float | None = None, samples=int | None
+    ):
+        """
+        Count the number of gates required to measure the norm of the given block encoding.
+
+        :param node: The node representing the vector of which to compute the norm.
+        :param precision:
+            The absolute precision, with which the norm should be computed. If
+            ``None``, ``self.default_precision`` is used instead.
+        :param failure_probability:
+            The maximum allowed failure probability, with which the absolute
+            error of the estimate may exceed the given precision. If ``None``,
+            ``self.default_failure_probability`` is used instead.
+        :param samples:
+            Number of times that the block encoding is executed. If given,
+            overides the number of samples computed from ``precision`` and
+            ``failure_probability``.
+        """
+        if precision is None:
+            precision = self.default_precision
+        if failure_probability is None:
+            failure_probability = self.default_failure_probability
+
+        if self.scheme == "exact":
+            raise ValueError('"exact" simulator does not support gate counting')
+
+        if self.scheme not in ["monte-carlo", "phase-estimation"]:
+            raise ValueError('Supported schemes are "exact", "monte-carlo" and "phase-estimation"')
+        if precision <= 0:
+            raise ValueError('Simulator with scheme != "exact" requires precision > 0')
+        if not 0 < failure_probability < 1:
+            raise ValueError('Simulator with scheme != "exact" requires 0 < failure_probability < 1')
+        normalization = node.normalization
+        normalized_precision = precision / normalization
+
+        if samples is not None:
+            if self.scheme == "monte-carlo":
+                samples = sample_bound(normalized_precision, failure_probability)
+            elif self.scheme == "phase-estimation":
+                # Following https://arxiv.org/abs/quant-ph/0005055
+                p0 = 8.0 / np.pi**2
+
+                # Find steps such that pi/steps + pi^2/steps^2 <= normalized_precision
+                steps = int(
+                    np.ceil(
+                        (np.pi + np.sqrt(np.pi**2 + 4 * normalized_precision * np.pi**2)) / (2 * normalized_precision)
+                    )
+                )
+
+                # Compute number of tries using Chernoff bound
+                gap = 2 * p0 - 1
+                tries = (
+                    1
+                    if failure_probability >= 1.0 - p0
+                    else max(1, int(np.ceil(2 * np.log(1.0 / failure_probability) / gap**2)))
+                )
+
+                samples = tries * steps
+
+        target_qubits = node.subspace_out.total_qubits
+        ancilla_count = max(
+            self.qubits - target_qubits - node.borrowed_ancilla_count(),
+            node.clean_ancilla_count(),
+        )
+        circuit = node._cached_circuit(ancilla_count, node.borrowed_ancilla_count(), False)
+        # This is actually slightly cheating, since this way the error
+        # of the circuit and sampling might add up to be larger than
+        # precision, but since we only use it to count the gates, the
+        # difference should only be logarithmic.
+        compiler = tq.CircuitCompiler.error_correctable_gate_set(normalized_precision)
+        compiled = compiler.compile_circuit(circuit._tq_circuit)
+
+        for gate in compiled.gates:
+            name = gate.name.lower()
+            if name == "globalphase":
+                continue
+            if name == "phase":
+                if gate.parameter < 3 * np.pi / 8:
+                    name = "t"
+                else:
+                    name = "s"
+            if name == "x":
+                if len(gate.control) == 1:
+                    name = "cx"
+                if len(gate.control) == 2:
+                    name = "ccx"
+            self.gate_count[name] = self.gate_count.get(name, 0) + samples
+        self.gate_count["t-depth"] = self.gate_count.get("t-depth", 0) + samples * t_depth(compiled)
+
 
 def t_depth(circuit: tq.QCircuit) -> int:
     table = {i: 0 for i in circuit.qubits}

--- a/src/unitaria/nodes/basic/compute_projection.py
+++ b/src/unitaria/nodes/basic/compute_projection.py
@@ -53,6 +53,11 @@ class SubspaceCircuit(Node):
     ) -> Circuit:
         return self.subspace.circuit(target[:-1], target[-1], clean_ancillae)
 
+    def _controlled_circuit(
+        self, control: int, target: Sequence[int], clean_ancillae: Sequence[int], borrowed_ancillae: Sequence[int]
+    ) -> Circuit:
+        return self.subspace.circuit(target[:-1], target[-1], clean_ancillae, control=control)
+
     def clean_ancilla_count(self) -> int:
         return self.subspace.clean_ancilla_count()
 

--- a/src/unitaria/subspace.py
+++ b/src/unitaria/subspace.py
@@ -12,6 +12,7 @@ import tequila as tq
 
 from unitaria.circuit import Circuit
 from unitaria.util import cached_property
+from unitaria.circuits.logic import multi_controlled_not
 
 
 class Subspace:
@@ -334,12 +335,11 @@ class Subspace:
         """
         return vector[self.enumerate_basis()]
 
-    def circuit(self, target: Sequence[int], flag: int, ancillae: Sequence[int]) -> Circuit:
+    def circuit(self, target: Sequence[int], flag: int, ancillae: Sequence[int], control: int | None = None) -> Circuit:
         """
         A circuit which checks whether a state is inside the subspace.
 
-        The result of the check will be stored in a flag qubit where
-        the index is the output of ``total_qubits``.
+        The result of the check will be stored in a flag qubit.
         Specifically, this qubit will be flipped if the other qubits
         represent a state outside the embedded vector space.
         """
@@ -368,9 +368,7 @@ class Subspace:
         if len(relevant_factors) == 1 and isinstance(relevant_factors[0][1], ControlledSubspace):
             index, factor = relevant_factors[0]
             return factor.circuit(
-                target=target[index : index + factor.total_qubits()],
-                flag=flag,
-                ancillae=ancillae,
+                target=target[index : index + factor.total_qubits()], flag=flag, ancillae=ancillae, control=control
             )
 
         # Next unused ancilla index
@@ -396,10 +394,16 @@ class Subspace:
             intermediate_flags.append(ancillae[ancilla_index])
             ancilla_index += 1
 
+        if control is not None:
+            intermediate_flags.append(control)
+
         # Apply the constructed circuit, add a multi-controlled NOT to determine
         # if the result flag is set, then uncompute the rest of the circuit
         circuit = (
-            circuit + tq.gates.X(target=flag, control=intermediate_flags) + tq.gates.X(target=flag) + circuit.adjoint()
+            circuit
+            + multi_controlled_not(target=flag, controls=intermediate_flags, clean_ancillae=ancillae[ancilla_index:])
+            + tq.gates.X(target=flag, control=control)
+            + circuit.adjoint()
         )
 
         return circuit
@@ -609,7 +613,7 @@ class ControlledSubspace(SubspaceFactor):
             )
         ]
 
-    def circuit(self, target: Sequence[int], flag: int, ancillae: Sequence[int]) -> Circuit:
+    def circuit(self, target: Sequence[int], flag: int, ancillae: Sequence[int], control: int | None = None) -> Circuit:
         """
         A circuit which checks whether a state is inside the subspace.
 
@@ -618,15 +622,37 @@ class ControlledSubspace(SubspaceFactor):
         represent a state outside the embedded vector space.
         """
         circuit = Circuit()
-        control = target[-1]
+        control2 = target[-1]
         if self.case_zero.dimension != 2**self.case_zero.total_qubits:
-            circuit_zero = self.case_zero.circuit(target=target[:-1], flag=flag, ancillae=ancillae)
-            circuit += tq.gates.X(target=control)
-            circuit += circuit_zero.add_controls(control)
-            circuit += tq.gates.X(target=control)
+            circuit += tq.gates.X(target=control2)
+            if control is not None:
+                if len(ancillae) > self.case_zero.clean_ancilla_count():
+                    circuit += tq.gates.Toffoli(control2, control, ancillae[-1])
+                    circuit += self.case_zero.circuit(
+                        target=target[:-1], flag=flag, ancillae=ancillae[:-1], control=ancillae[-1]
+                    )
+                    circuit += tq.gates.Toffoli(control2, control, ancillae[-1])
+                else:
+                    circuit += self.case_zero.circuit(
+                        target=target[:-1], flag=flag, ancillae=ancillae, control=control2
+                    ).add_control([control])
+            else:
+                circuit += self.case_zero.circuit(target=target[:-1], flag=flag, ancillae=ancillae, control=control2)
+            circuit += tq.gates.X(target=control2)
         if self.case_one.dimension != 2**self.case_one.total_qubits:
-            circuit_one = self.case_one.circuit(target=target[:-1], flag=flag, ancillae=ancillae)
-            circuit += circuit_one.add_controls(control)
+            if control is not None:
+                if len(ancillae) > self.case_one.clean_ancilla_count():
+                    circuit += tq.gates.Toffoli(control2, control, ancillae[-1])
+                    circuit += self.case_one.circuit(
+                        target=target[:-1], flag=flag, ancillae=ancillae[:-1], control=ancillae[-1]
+                    )
+                    circuit += tq.gates.Toffoli(control2, control, ancillae[-1])
+                else:
+                    circuit += self.case_one.circuit(
+                        target=target[:-1], flag=flag, ancillae=ancillae, control=control2
+                    ).add_control([control])
+            else:
+                circuit += self.case_one.circuit(target=target[:-1], flag=flag, ancillae=ancillae, control=control2)
         return circuit
 
     def clean_ancilla_count(self) -> int:

--- a/tests/estimator/test_simulator.py
+++ b/tests/estimator/test_simulator.py
@@ -25,3 +25,18 @@ def test_monte_carlo():
             new_gate_count = sum(simulator.gate_count.values())
             assert (new_gate_count - old_gate_count) > 2 * n * (node.normalization / precision) ** 2
             old_gate_count = new_gate_count
+
+
+def test_phase_estimation():
+    rng = np.random.default_rng(0)
+    for precision in [0.1, 0.01]:
+        simulator = ut.Simulator("phase-estimation", precision, count_gates=True)
+        old_gate_count = 0
+        for i in range(1, 3):
+            n = rng.integers(1, 2**i)
+            v = rng.standard_normal(2 * n)
+            node = ut.ConstantVector(v)
+            assert np.abs(simulator.estimate_norm(node[:n]) - np.linalg.norm(v[:n])) < precision
+            new_gate_count = sum(simulator.gate_count.values())
+            assert (new_gate_count - old_gate_count) > 2 * n * (node.normalization / precision)
+            old_gate_count = new_gate_count


### PR DESCRIPTION
Based on #131.

This is just the default amplitude estimation using phase estimation from https://arxiv.org/pdf/quant-ph/0005055. I don't think it makes too much sense to integrate this into `BackendEstimator`, as it is probably to expensive to simulate, and current hardware is not at a point where phase estimation makes sense for block encodings.