### PR TITLE
114 negation and scalar product operators do not behave like expected

### DIFF
--- a/src/unitaria/nodes/basic/scale.py
+++ b/src/unitaria/nodes/basic/scale.py
@@ -110,4 +110,6 @@ class Scale(Node):
         return self.A.borrowed_ancilla_count()
 
 
+Node.__mul__ = lambda A, s: Scale(A, s)
 Node.__rmul__ = lambda A, s: Scale(A, s)
+Node.__neg__ = lambda A: Scale(A, -1)

--- a/src/unitaria/nodes/constants/constant_unitary.py
+++ b/src/unitaria/nodes/constants/constant_unitary.py
@@ -14,7 +14,7 @@ class ConstantUnitary(Node):
     Node representing the given unitary
 
     Can also be a rectangular matrix with orthonormal columns, i.e. a matrix V
-    such that either $V^\\dag V$ or $V V^\\dag$ is unitary.
+    such that either :math:`V^\\dag V` or :math:`V V^\\dag` is unitary.
 
     :param unitary: The unitary which should be implemented
     :raises ValueError: If the provided matrix is not unitary.

--- a/src/unitaria/nodes/qsvt/qsvt.py
+++ b/src/unitaria/nodes/qsvt/qsvt.py
@@ -224,12 +224,16 @@ class QSVT(Node):
     exactly correspond to those angles. If a polynomial P is given, the resulting
     block encoding will encode P(A). The normalization of the block encoding will
     be roughly the sup-norm
-    $$ \\max_{x \\in [-\\gamma_A, \\gamma_A]} |P(x)| $$
+
+    .. math::
+
+       \\max_{x \\in [-\\gamma_A, \\gamma_A]} |P(x)|
+
     though it may be slightly larger.
 
     If a polynomial is given, it should best be specified using the
     `np.polynomial.Chebyshev` class, and the `domain` attribute should
-    correspond to ``[-\\gamma_A, \\gamma_A]`` for reasons of numerical
+    correspond to :math:`[-\\gamma_A, \\gamma_A]` for reasons of numerical
     stability.
 
     :param A: The matrix to be transformed

--- a/tests/nodes/test_basic_ops.py
+++ b/tests/nodes/test_basic_ops.py
@@ -17,8 +17,12 @@ def test_scale():
     A = ut.Increment(bits=1)
 
     ut.verify(1 * A)
+    ut.verify(A * 1)
     ut.verify((-1) * A)
+    ut.verify(A * (-1))
     ut.verify((-2) * A)
+    ut.verify(A * (-2))
+    ut.verify(-A)
     ut.verify(ut.Scale(A, 0.5, absolute=True))
     ut.verify(ut.Scale(A, 0.5, remove_efficiency=2.34))
     ut.verify(ut.Scale(A, 0.5, remove_efficiency=2.34, absolute=True))


### PR DESCRIPTION
**issue 114**
- added option for scalar multiplication from right and minus before a node
- small addition for basic node test to check also for these

**issue 117**
- edited some $$ and exchanged them with :math: so the docs render the latex correctly 

Closes #117 Closes #114 