### PR TITLE
Fix bug 141

### DIFF
--- a/src/unitaria/circuits/state_prep.py
+++ b/src/unitaria/circuits/state_prep.py
@@ -20,15 +20,16 @@ def prepare_state(state: npt.NDArray[complex], target: Sequence[int]) -> tq.QCir
     assert np.isclose(np.linalg.norm(state), 1)
     state = state.astype(complex)
 
-    theta = dict()
-    phi = dict()
-    combined = dict()
+    theta = {}
+    phi = {}
+    combined = {}
     for bit in range(n):
         for i in range(2 ** (n - bit - 1)):
             a0 = state[2 * i] if bit == 0 else combined[bit - 1, 2 * i]
             a1 = state[2 * i + 1] if bit == 0 else combined[bit - 1, 2 * i + 1]
-            r = np.hypot(abs(a0), abs(a1))
-            theta[bit, i] = 2 * np.arccos(np.abs(a0) / r) if r != 0 else 0
+            m0, m1 = np.abs(a0), np.abs(a1)
+            r = np.hypot(m0, m1)
+            theta[bit, i] = 2 * np.arctan2(m1, m0)
             phi[bit, i] = np.angle(a1) - np.angle(a0)
             combined[bit, i] = np.exp(((np.angle(a0) + np.angle(a1)) / 2) * 1j) * r
 


### PR DESCRIPTION
Closes #141 by circumventing the divison inside the arccos by letting it handle arctan2. 

Originally I thought that numerical instability of np.abs might be the cause, but it is much more probalble that cummulating rounding errors in np.hypot and in the division might cause the bug. 
Calculating theta via arctan is save, because we have the values of the legs of the triangle and therefore instead of using r, what is subject to rouding, we just use the tan() formula for finding the angle. That saves two sources of rounding errors (assuming arctan2 does not introduce some internally) and at least in my testing the RuntimeWarning did not occur anymore. 

I also replaced the dict() calls with literals. This linter rule also brings a little performance: https://docs.astral.sh/ruff/rules/unnecessary-collection-call/.
